### PR TITLE
✨ Add include_rel & update DevelopmentalStage and Tissue

### DIFF
--- a/bionty/base/_ontology.py
+++ b/bionty/base/_ontology.py
@@ -114,20 +114,30 @@ class Ontology(pronto.Ontology):
             if len(synonyms) == 0:
                 synonyms = None  # type:ignore
 
-            # get 1st degree parents and part of relatonships if specified as a list
+            # get 1st degree parents and additional relatonships (include_rel such as 'part_of')
             superclasses = [
-                s.id for s in term.superclasses(distance=1, with_self=False).to_set()
+                superclass.id
+                for superclass in term.superclasses(
+                    distance=1, with_self=False
+                ).to_set()
             ]
 
             if include_rel is not None:
                 if include_rel in [i.id for i in term.relationships]:
                     superclasses.extend(
-                        [s.id for s in term.objects(self.get_relationship(include_rel))]
+                        [
+                            superclass.id
+                            for superclass in term.objects(
+                                self.get_relationship(include_rel)
+                            )
+                        ]
                     )
 
             if prefix_list is not None:
                 superclasses = [
-                    s for s in superclasses if s.startswith(tuple(prefix_list))
+                    superclass
+                    for superclass in superclasses
+                    if superclass.startswith(tuple(prefix_list))
                 ]
 
             df_values.append((term.id, term.name, definition, synonyms, superclasses))

--- a/bionty/base/_public_ontology.py
+++ b/bionty/base/_public_ontology.py
@@ -337,8 +337,8 @@ class PublicOntology:
             A Pandas DataFrame of the ontology.
 
         Examples:
-            >>> import bionty.base as bt
-            >>> bt.Gene().df()
+            >>> import bionty.base as bt_base
+            >>> bt_base.Gene().df()
         """
         if "ontology_id" in self._df.columns:
             return self._df.set_index("ontology_id")
@@ -367,8 +367,8 @@ class PublicOntology:
             A boolean array indicating compliance validation.
 
         Examples:
-            >>> import bionty.base as bt
-            >>> public = bt.Gene()
+            >>> import bionty.base as bt_base
+            >>> public = bt_base.Gene()
             >>> gene_symbols = ["A1CF", "A1BG", "FANCD1", "FANCD20"]
             >>> public.validate(gene_symbols, field=public.symbol)
         """
@@ -411,8 +411,8 @@ class PublicOntology:
                 `__validated__` column indicating compliance validation.
 
         Examples:
-            >>> import bionty.base as bt
-            >>> public = bt.Gene()
+            >>> import bionty.base as bt_base
+            >>> public = bt_base.Gene()
             >>> gene_symbols = ["A1CF", "A1BG", "FANCD1", "FANCD20"]
             >>> public.inspect(gene_symbols, field=public.symbol)
         """
@@ -467,8 +467,8 @@ class PublicOntology:
             standardized names as values.
 
         Examples:
-            >>> import bionty.base as bt
-            >>> public = bt.Gene()
+            >>> import bionty.base as bt_base
+            >>> public = bt_base.Gene()
             >>> gene_symbols = ["A1CF", "A1BG", "FANCD1", "FANCD20"]
             >>> standardized_symbols = public.standardize(gene_symbols, public.symbol)
         """
@@ -521,8 +521,8 @@ class PublicOntology:
             A NamedTuple of lookup information of the field values.
 
         Examples:
-            >>> import bionty.base as bt
-            >>> lookup = bt.CellType().lookup()
+            >>> import bionty.base as bt_base
+            >>> lookup = bt_base.CellType().lookup()
             >>> lookup.cd103_positive_dendritic_cell
             >>> lookup_dict = lookup.dict()
             >>> lookup['CD103-positive dendritic cell']
@@ -561,8 +561,8 @@ class PublicOntology:
             Ranked search results.
 
         Examples:
-            >>> import bionty.base as bt
-            >>> public = bt.CellType()
+            >>> import bionty.base as bt_base
+            >>> public = bt_base.CellType()
             >>> public.search("gamma delta T cell")
         """
         from lamin_utils._search import search
@@ -591,9 +591,9 @@ class PublicOntology:
             2. A pd.DataFrame.compare result which denotes all changes in `self` and `other`.
 
         Examples:
-            >>> import bionty.base as bt
-            >>> public_1 = bt.Disease(source="mondo", version="2023-04-04")
-            >>> public_2 = bt.Disease(source="mondo", version="2023-04-04")
+            >>> import bionty.base as bt_base
+            >>> public_1 = bt_base.Disease(source="mondo", version="2023-04-04")
+            >>> public_2 = bt_base.Disease(source="mondo", version="2023-04-04")
             >>> new_entries, modified_entries = public_1.diff(public_2)
             >>> print(new_entries.head())
             >>> print(modified_entries.head())

--- a/bionty/base/_public_ontology.py
+++ b/bionty/base/_public_ontology.py
@@ -50,6 +50,7 @@ class PublicOntology:
         organism: str | None = None,
         *,
         include_id_prefixes: dict[str, list[str]] | None = None,
+        include_rel: str | None = None,
         **kwargs,
     ):
         # backward compat for species -> organism
@@ -94,6 +95,7 @@ class PublicOntology:
 
         self._set_file_paths()
         self.include_id_prefixes = include_id_prefixes
+        self.include_rel = include_rel
 
         # df is only read into memory at the init to improve performance
         df = self._load_df()
@@ -302,7 +304,9 @@ class PublicOntology:
         if not self._url.endswith("parquet"):
             if not self._local_parquet_path.exists():
                 df = self.to_pronto().to_df(
-                    source=self.source, include_id_prefixes=self.include_id_prefixes
+                    source=self.source,
+                    include_id_prefixes=self.include_id_prefixes,
+                    include_rel=self.include_rel,
                 )
                 df.to_parquet(self._local_parquet_path)
 
@@ -333,7 +337,7 @@ class PublicOntology:
             A Pandas DataFrame of the ontology.
 
         Examples:
-            >>> import bionty.base as bionty_base
+            >>> import bionty.base as bt
             >>> bt.Gene().df()
         """
         if "ontology_id" in self._df.columns:
@@ -363,7 +367,7 @@ class PublicOntology:
             A boolean array indicating compliance validation.
 
         Examples:
-            >>> import bionty.base as bionty_base
+            >>> import bionty.base as bt
             >>> public = bt.Gene()
             >>> gene_symbols = ["A1CF", "A1BG", "FANCD1", "FANCD20"]
             >>> public.validate(gene_symbols, field=public.symbol)
@@ -407,7 +411,7 @@ class PublicOntology:
                 `__validated__` column indicating compliance validation.
 
         Examples:
-            >>> import bionty.base as bionty_base
+            >>> import bionty.base as bt
             >>> public = bt.Gene()
             >>> gene_symbols = ["A1CF", "A1BG", "FANCD1", "FANCD20"]
             >>> public.inspect(gene_symbols, field=public.symbol)
@@ -451,7 +455,7 @@ class PublicOntology:
                 multiple names, determines which duplicates to mark as
                 `pd.DataFrame.duplicated`
             mute: Whether to mute logging. Defaults to False.
-
+            Keep: Which standardized name to keep.
                     - "first": returns the first mapped standardized name
                     - "last": returns the last mapped standardized name
                     - `False`: returns all mapped standardized name
@@ -463,7 +467,7 @@ class PublicOntology:
             standardized names as values.
 
         Examples:
-            >>> import bionty.base as bionty_base
+            >>> import bionty.base as bt
             >>> public = bt.Gene()
             >>> gene_symbols = ["A1CF", "A1BG", "FANCD1", "FANCD20"]
             >>> standardized_symbols = public.standardize(gene_symbols, public.symbol)
@@ -517,7 +521,7 @@ class PublicOntology:
             A NamedTuple of lookup information of the field values.
 
         Examples:
-            >>> import bionty.base as bionty_base
+            >>> import bionty.base as bt
             >>> lookup = bt.CellType().lookup()
             >>> lookup.cd103_positive_dendritic_cell
             >>> lookup_dict = lookup.dict()
@@ -557,7 +561,7 @@ class PublicOntology:
             Ranked search results.
 
         Examples:
-            >>> import bionty.base as bionty_base
+            >>> import bionty.base as bt
             >>> public = bt.CellType()
             >>> public.search("gamma delta T cell")
         """
@@ -587,7 +591,7 @@ class PublicOntology:
             2. A pd.DataFrame.compare result which denotes all changes in `self` and `other`.
 
         Examples:
-            >>> import bionty.base as bionty_base
+            >>> import bionty.base as bt
             >>> public_1 = bt.Disease(source="mondo", version="2023-04-04")
             >>> public_2 = bt.Disease(source="mondo", version="2023-04-04")
             >>> new_entries, modified_entries = public_1.diff(public_2)

--- a/bionty/base/entities/_developmentalstage.py
+++ b/bionty/base/entities/_developmentalstage.py
@@ -29,5 +29,6 @@ class DevelopmentalStage(PublicOntology):
             version=version,
             organism=organism,
             include_id_prefixes={"hsapdv": ["HsapDv"], "mmusdv": ["MmusDv"]},
+            include_rel="part_of",
             **kwargs,
         )

--- a/bionty/base/entities/_tissue.py
+++ b/bionty/base/entities/_tissue.py
@@ -29,5 +29,6 @@ class Tissue(PublicOntology):
             version=version,
             organism=organism,
             include_id_prefixes={"uberon": ["UBERON"]},
+            include_rel="part_of",
             **kwargs,
         )

--- a/bionty/base/sources.yaml
+++ b/bionty/base/sources.yaml
@@ -368,6 +368,9 @@ Drug:
 DevelopmentalStage:
   hsapdv:
     human:
+      2024-05-28:
+        url: https://github.com/obophenotype/developmental-stage-ontologies/releases/download/v2024-05-28/hsapdv.owl
+        md5: ""
       2020-03-10:
         url: http://aber-owl.net/media/ontologies/HSAPDV/11/hsapdv.owl
         md5: 52181d59df84578ed69214a5cb614036
@@ -375,6 +378,9 @@ DevelopmentalStage:
     website: https://github.com/obophenotype/developmental-stage-ontologies/wiki/HsapDv
   mmusdv:
     mouse:
+      2024-05-28:
+        url: https://github.com/obophenotype/developmental-stage-ontologies/releases/download/v2024-05-28/mmusdv.owl
+        md5: ""
       2020-03-10:
         url: http://aber-owl.net/media/ontologies/MMUSDV/9/mmusdv.owl
         md5: 5bef72395d853c7f65450e6c2a1fc653

--- a/bionty/base/sources.yaml
+++ b/bionty/base/sources.yaml
@@ -155,6 +155,9 @@ CellType:
 Tissue:
   uberon:
     all:
+      2024-08-07:
+        url: http://purl.obolibrary.org/obo/uberon/releases/2024-08-07/uberon.owl
+        md5: ""
       2024-05-13:
         url: http://purl.obolibrary.org/obo/uberon/releases/2024-05-13/uberon.owl
         md5: dc473b764acfe765be31250c853ef23d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "lamindb",


### PR DESCRIPTION
Fixes https://github.com/laminlabs/bionty/issues/37
Fixes https://github.com/laminlabs/bionty/issues/81

* Adds a new `include_rel` parameter which allows for additional relationships to be specified that are also added to parents. In particular, we are interested in `part_of`.
* Uses `part_of` for DevelopmentalStage and Tissue
* Adds new versions for DevelopmentalStage human and mouse (2024-08-07)
* Adds a new version for Tissue (2024-08-07)