### PR TITLE
📝 Fix docs for use with inheritance, formatting errors, and refactor

### DIFF
--- a/bionty/base/__init__.py
+++ b/bionty/base/__init__.py
@@ -1,17 +1,6 @@
-"""Bionty base is a standalone version of Bionty without lamindb support.
-
-Overview
-========
+"""Access to public ontologies.
 
 `bionty.base` is the read-only interface for public ontology that underlies bionty and doesn't require a lamindb instance.
-
-Installation
-============
-
->>> pip install bionty
-
-Quickstart
-----------
 
 Import the package:
 
@@ -50,12 +39,10 @@ Bionty base provides access to several entities, most of which are also supporte
    BFXPipeline
    BioSample
 
-Base model of entity classes
-----------------------------
+Base class
+----------
 
-[Pronto Ontology objects](https://pronto.readthedocs.io/en/stable/api/pronto.Ontology.html) can be accessed via {entity}.to_pronto():
-
-   bt_base.Gene().to_pronto()
+`Pronto Ontology objects <https://pronto.readthedocs.io/en/stable/api/pronto.Ontology.html>`__ can be accessed via `{entity}.to_pronto()`.
 
 .. autosummary::
    :toctree: .
@@ -63,8 +50,8 @@ Base model of entity classes
    PublicOntology
    PublicOntologyField
 
-PublicOntology sources
-----------------------
+Ontology sources
+----------------
 
 .. autosummary::
    :toctree: .
@@ -74,8 +61,8 @@ PublicOntology sources
    reset_sources
    settings
 
-External API
-------------
+Pronto Ontology
+---------------
 
 .. autosummary::
    :toctree: .

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -358,12 +358,12 @@ class BioRecord(Record, HasParents, CanValidate):
         organism: str | Record | None = None,
         source: Source | None = None,
     ) -> PublicOntology | StaticReference:
-        """The corresponding PublicOntology object.
+        """The corresponding :class:`docs:bionty.base.PublicOntology` object.
 
-        Note that the source is auto-configured and tracked via :meth:`bionty.Source`.
+        Note that the source is auto-configured and tracked via :class:`docs:bionty.Source`.
 
         See Also:
-            `PublicOntology <https://lamin.ai/docs/public-ontologies>`__
+            :doc:`docs:public-ontologies`
 
         Examples:
             >>> celltype_pub = bionty.CellType.public()


### PR DESCRIPTION
Mostly addresses docs failing in sub-projects because the main docs weren't referenced and we're now documenting inherited objects: https://laminlabs.slack.com/archives/C07DB677JF6/p1725288908080799

Markdown was used:
<img width="808" alt="image" src="https://github.com/user-attachments/assets/54c27b9d-6326-4624-a650-bb80cd17ac7f">
