### PR TITLE
📝 More consistent and simpler docs

### DIFF
--- a/bionty/__init__.py
+++ b/bionty/__init__.py
@@ -41,12 +41,10 @@ Manage synonyms:
 >>> cell_type_new.add_synonyms(["my cell type", "my cell"])
 >>> cell_type_new.set_abbr("MCT")
 
-.. note::
+Detailed guides:
 
-   Read the guides:
-
-   - :doc:`docs:public-ontologies`
-   - :doc:`docs:bio-registries`
+- :doc:`docs:public-ontologies`
+- :doc:`docs:bio-registries`
 
 Registries:
 

--- a/bionty/__init__.py
+++ b/bionty/__init__.py
@@ -1,54 +1,21 @@
-"""Registries for basic biological entities, coupled to public ontologies.
+"""Basic biological entities, coupled to public ontologies [`source <https://github.com/laminlabs/bionty/blob/main/bionty/models.py>`__].
 
-.. _bionty-overview:
-
-Overview
-========
-
-- Create records from entries in public ontologies using `.from_source()`.
-- Access full underlying public ontologies via `.public()` to search & bulk-create records.
-- Create in-house ontologies by using hierarchical relationships among records (`.parents`).
+- Create records from public ontologies using `.from_source()`.
+- Access public ontologies via `.public()` to search & bulk-create records.
+- Use hierarchical relationships among records (`.parents`).
 - Use `.synonyms` and `.abbr` to manage synonyms.
-
-All registries inherit from :class:`~lamindb.core.CanValidate` &
-:class:`~lamindb.core.HasParents` to standardize, validate & annotate data, and from
-:class:`~lamindb.core.Record` for query & search.
 
 .. dropdown:: How to ensure reproducibility across different versions of public ontologies?
 
-   It's important to track versions of external data dependencies.
-
-   `bionty` manages it under the hood:
+   `bionty` manages versions of external data dependencies.
 
    - Versions of ontology sources are auto-tracked in :class:`Source`.
    - Records are indexed by universal ids, created by hashing `ontology_id` for portability across databases.
 
-`bionty.base` is the read-only interface for public ontology that underlies bionty and doesn't require a lamindb instance.
+Install and mount `bionty` in a new instance:
 
-Import it by running:
-
->>> import bionty.base as bt_base
-
-See {mod}`bionty.base` for details.
-
-.. _bionty-installation:
-
-Installation
-============
-
->>> pip install 'lamindb[bionty]'
-
-.. _bionty-setup:
-
-Setup
-=====
-
+>>> pip install 'bionty'
 >>> lamin init --storage <storage_name> --schema bionty
-
-.. _bionty-quickstart:
-
-Quickstart
-==========
 
 Import bionty:
 
@@ -87,16 +54,7 @@ Manage synonyms:
    - :doc:`docs:public-ontologies`
    - :doc:`docs:bio-registries`
 
-.. _bionty-api:
-
-API
-===
-
-Import the package::
-
-   import bionty as bt
-
-Basic biological registries:
+Registries:
 
 .. autosummary::
    :toctree: .
@@ -129,18 +87,12 @@ Ontology versions:
 
    Source
 
-Developer API:
+Submodules:
 
 .. autosummary::
    :toctree: .
 
    core
-
-Bionty base:
-
-.. autosummary::
-   :toctree: .
-
    base
 
 """

--- a/bionty/__init__.py
+++ b/bionty/__init__.py
@@ -4,13 +4,7 @@
 - Access public ontologies via `.public()` to search & bulk-create records.
 - Use hierarchical relationships among records (`.parents`).
 - Use `.synonyms` and `.abbr` to manage synonyms.
-
-.. dropdown:: How to ensure reproducibility across different versions of public ontologies?
-
-   `bionty` manages versions of external data dependencies.
-
-   - Versions of ontology sources are auto-tracked in :class:`Source`.
-   - Records are indexed by universal ids, created by hashing `ontology_id` for portability across databases.
+- Manage ontology versions.
 
 Install and mount `bionty` in a new instance:
 


### PR DESCRIPTION
It now takes a lot less vertical scrolling to get to the meat. And it's consistent with the other schema modules per

- https://github.com/laminlabs/lamindb/pull/2047

Before | After
--- | ---
<img width="810" alt="image" src="https://github.com/user-attachments/assets/22e3009b-960e-4974-9ad1-3e9dfd6dcdaa"> | <img width="819" alt="image" src="https://github.com/user-attachments/assets/b5e04e37-bdf1-4995-8419-3bff40235145">
<img width="804" alt="image" src="https://github.com/user-attachments/assets/7c64bf84-bc6f-43f0-9fd4-b21899a4d680"> | <img width="811" alt="image" src="https://github.com/user-attachments/assets/ffd7b09f-7266-40f7-965a-16502d7662b5">

