### PR TITLE
🐛 Hide from_public from TOC

### DIFF
--- a/bionty/models.py
+++ b/bionty/models.py
@@ -391,17 +391,19 @@ class BioRecord(Record, HasParents, CanValidate):
                 source = Source.filter(**kwargs).first()
             return StaticReference(source)
 
-    # deprecated in favor of from_source
     @classmethod
     def _from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
-        logger.warning("`.from_public()` is deprecated, use `.from_source()`!'")
+        """Deprecated in favor of `from_source`."""
+        logger.warning(
+            "`.from_public()` is deprecated and will be removed in a future version. Use `.from_source()` instead!"
+        )
         return cls.from_source(*args, **kwargs)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        # Conditionally add from_public to the subclass
         import sys
 
+        # Deprecated methods
         if "sphinx" not in sys.modules:
             cls.from_public = cls._from_public
 

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -441,7 +441,7 @@ class BioRecord(Record, HasParents, CanValidate):
     @deprecated(".from_source()")
     @classmethod
     def from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
-        """Deprecated.
+        """:noindex:  # noqa: D415.
 
         :meta private:
 

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -217,7 +217,10 @@ class BioRecord(Record, HasParents, CanValidate):
     def __getattr__(cls, name):
         """Forwards deprecated methods."""
         if name == "from_public":
-            return cls.from_source  # Delegate old method calls to the private method
+            logger.warning(
+                "`.from_public()` is deprecated and will be removed in a future version. Use `.from_source()` instead!'"
+            )
+            return cls.from_source
         raise AttributeError(f"'{cls.__name__}' object has no attribute '{name}'")
 
     @classmethod

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -441,7 +441,10 @@ class BioRecord(Record, HasParents, CanValidate):
     @deprecated(".from_source()")
     @classmethod
     def from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
-        """:meta private:
+        """Deprecated.
+
+        :meta private:
+
         Create a record or records from public reference based on a single field value.
 
         Notes:

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -214,6 +214,12 @@ class BioRecord(Record, HasParents, CanValidate):
 
         super().__init__(*args, **kwargs)
 
+    def __getattr__(cls, name):
+        """Forwards deprecated methods."""
+        if name == "from_public":
+            return cls.from_source  # Delegate old method calls to the private method
+        raise AttributeError(f"'{cls.__name__}' object has no attribute '{name}'")
+
     @classmethod
     def import_from_source(
         cls,
@@ -435,15 +441,6 @@ class BioRecord(Record, HasParents, CanValidate):
                 return None
             else:
                 return results
-
-    @classmethod
-    def from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
-        """Test.
-
-        :meta private:
-
-        """
-        return cls.from_source(*args, **kwargs)
 
     def save(self, *args, **kwargs) -> BioRecord:
         """Save the record and its parents recursively."""

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -436,26 +436,12 @@ class BioRecord(Record, HasParents, CanValidate):
             else:
                 return results
 
-    from lamindb_setup.core._deprecated import deprecated
-
-    @deprecated(".from_source()")
     @classmethod
     def from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
-        """:noindex:  # noqa: D415.
+        """Test.
 
         :meta private:
 
-        Create a record or records from public reference based on a single field value.
-
-        Notes:
-            For more info, see tutorial :doc:`docs:bionty`
-
-            Bulk create records via :meth:`~docs:lamindb.core.CanValidate.from_values`.
-
-        Examples:
-            Create a record by passing a field value:
-
-            >>> record = bionty.Gene.from_public(symbol="TCF7", organism="human")
         """
         return cls.from_source(*args, **kwargs)
 

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -436,10 +436,13 @@ class BioRecord(Record, HasParents, CanValidate):
             else:
                 return results
 
-    # deprecated
+    from lamindb_setup.core._deprecated import deprecated
+
+    @deprecated(".from_source()")
     @classmethod
     def from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
-        """Create a record or records from public reference based on a single field value.
+        """:meta private:
+        Create a record or records from public reference based on a single field value.
 
         Notes:
             For more info, see tutorial :doc:`docs:bionty`
@@ -450,9 +453,7 @@ class BioRecord(Record, HasParents, CanValidate):
             Create a record by passing a field value:
 
             >>> record = bionty.Gene.from_public(symbol="TCF7", organism="human")
-
         """
-        logger.warning("`.from_public()` is deprecated, use `.from_source()`!'")
         return cls.from_source(*args, **kwargs)
 
     def save(self, *args, **kwargs) -> BioRecord:

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -214,14 +214,10 @@ class BioRecord(Record, HasParents, CanValidate):
 
         super().__init__(*args, **kwargs)
 
-    def __getattr__(cls, name):
-        """Forwards deprecated methods."""
-        if name == "from_public":
-            logger.warning(
-                "`.from_public()` is deprecated and will be removed in a future version. Use `.from_source()` instead!'"
-            )
-            return cls.from_source
-        raise AttributeError(f"'{cls.__name__}' object has no attribute '{name}'")
+    @classmethod
+    def __dir__(cls):
+        """Customize the attributes listed by dir() and hide from_public from docs."""
+        return [item for item in super().__dir__() if item != "from_public"]
 
     @classmethod
     def import_from_source(
@@ -399,6 +395,22 @@ class BioRecord(Record, HasParents, CanValidate):
                         kwargs["organism"] = organism
                 source = Source.filter(**kwargs).first()
             return StaticReference(source)
+
+    # deprecated
+    @classmethod
+    def from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
+        """Create a record or records from public reference based on a single field value.
+
+        Notes:
+            For more info, see tutorial :doc:`docs:bionty`
+            Bulk create records via :meth:`~docs:lamindb.core.CanValidate.from_values`.
+
+        Examples:
+            Create a record by passing a field value:
+            >>> record = bionty.Gene.from_public(symbol="TCF7", organism="human").
+        """
+        logger.warning("`.from_public()` is deprecated, use `.from_source()`!'")
+        return cls.from_source(*args, **kwargs)
 
     @classmethod
     def from_source(

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -397,7 +397,13 @@ class BioRecord(Record, HasParents, CanValidate):
         logger.warning("`.from_public()` is deprecated, use `.from_source()`!'")
         return cls.from_source(*args, **kwargs)
 
-    from_public = _from_public
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # Conditionally add from_public to the subclass
+        import sys
+
+        if "sphinx" not in sys.modules:
+            cls.from_public = cls._from_public
 
     @classmethod
     def from_source(

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -215,11 +215,6 @@ class BioRecord(Record, HasParents, CanValidate):
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def __dir__(cls):
-        """Customize the attributes listed by dir() and hide from_public from docs."""
-        return [item for item in super().__dir__() if item != "from_public"]
-
-    @classmethod
     def import_from_source(
         cls,
         source: Source | None = None,
@@ -396,21 +391,13 @@ class BioRecord(Record, HasParents, CanValidate):
                 source = Source.filter(**kwargs).first()
             return StaticReference(source)
 
-    # deprecated
+    # deprecated in favor of from_source
     @classmethod
-    def from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
-        """Create a record or records from public reference based on a single field value.
-
-        Notes:
-            For more info, see tutorial :doc:`docs:bionty`
-            Bulk create records via :meth:`~docs:lamindb.core.CanValidate.from_values`.
-
-        Examples:
-            Create a record by passing a field value:
-            >>> record = bionty.Gene.from_public(symbol="TCF7", organism="human").
-        """
+    def _from_public(cls, *args, **kwargs) -> BioRecord | list[BioRecord] | None:
         logger.warning("`.from_public()` is deprecated, use `.from_source()`!'")
         return cls.from_source(*args, **kwargs)
+
+    from_public = _from_public
 
     @classmethod
     def from_source(


### PR DESCRIPTION
Fixes https://github.com/laminlabs/bionty/issues/134

### Things I Tried That Didn't Work:

1. **`__getattr__` on the Class**: This only works for instance attributes, not class methods like `from_public`. It didn't intercept class-level method calls.

2. **Metaclass Solution**: Adding a custom metaclass (`BioRecordMeta`) caused conflicts with existing metaclasses used by Django models, resulting in a "metaclass conflict" error.

3. **Removing the Docstring (`__doc__ = None`)**: While this removed the method's documentation, `from_public` still showed up in Sphinx's table of contents (TOC) since the method itself was still present.

4. **`__dir__` Override**: Hiding the method via `__dir__` didn't prevent Sphinx from listing `from_public` because `Sphinx` relies on more than just `dir()` for introspection.

5. **Sphinx Event Hook**: Registering the `autodoc-skip-member` event handler required access to `conf.py`.

### What Finally Worked:

- **Using `__init_subclass__`**: This method was overridden to dynamically add the `from_public` method to each subclass only when Sphinx was **not** running. This ensures that `from_public` is available for backward compatibility at runtime but hidden from Sphinx documentation.