### PR TITLE
🎨 Raise `OrganismNotSet` instead of `AssertionError` when `organism` is not set

### DIFF
--- a/bionty/_bionty.py
+++ b/bionty/_bionty.py
@@ -54,7 +54,7 @@ def create_or_get_organism_record(
                 "uid",
             }:
                 return None
-            raise AssertionError(
+            raise ValueError(
                 f"{registry.__name__} requires to specify a organism name via `organism=` or `bionty.settings.organism=`!"
             )
 

--- a/bionty/_bionty.py
+++ b/bionty/_bionty.py
@@ -7,6 +7,7 @@ from lamin_utils import logger
 from lnschema_core.models import Record
 
 import bionty.base as bt_base
+from bionty.core.exceptions import OrganismNotSet
 
 from . import ids
 
@@ -54,7 +55,7 @@ def create_or_get_organism_record(
                 "uid",
             }:
                 return None
-            raise ValueError(
+            raise OrganismNotSet(
                 f"{registry.__name__} requires to specify a organism name via `organism=` or `bionty.settings.organism=`!"
             )
 

--- a/bionty/_bionty.py
+++ b/bionty/_bionty.py
@@ -7,12 +7,17 @@ from lamin_utils import logger
 from lnschema_core.models import Record
 
 import bionty.base as bt_base
-from bionty.core.exceptions import OrganismNotSet
 
 from . import ids
 
 if TYPE_CHECKING:
     from types import ModuleType
+
+
+class OrganismNotSet(SystemExit):
+    """The `organism` parameter was not passed or is not globally set."""
+
+    pass
 
 
 def create_or_get_organism_record(

--- a/bionty/core/_add_ontology.py
+++ b/bionty/core/_add_ontology.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Iterable
 
 from lamin_utils import logger
 

--- a/bionty/core/exceptions.py
+++ b/bionty/core/exceptions.py
@@ -1,9 +1,0 @@
-# inheriting from SystemExit has the sole purpose of suppressing
-# the traceback - this isn't optimal but the current best solution
-# https://laminlabs.slack.com/archives/C04A0RMA0SC/p1726856875597489
-
-
-class OrganismNotSet(SystemExit):
-    """The `organism` parameter was not passed or is not globally set."""
-
-    pass

--- a/bionty/core/exceptions.py
+++ b/bionty/core/exceptions.py
@@ -1,0 +1,9 @@
+# inheriting from SystemExit has the sole purpose of suppressing
+# the traceback - this isn't optimal but the current best solution
+# https://laminlabs.slack.com/archives/C04A0RMA0SC/p1726856875597489
+
+
+class OrganismNotSet(SystemExit):
+    """The `organism` parameter was not passed or is not globally set."""
+
+    pass


### PR DESCRIPTION
Fixes #142 

- Now raising a custom `OrganismNotSet` error which suppresses the django traceback.