### PR TITLE
✨ Add field support for bionty base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,5 @@ _dynamic/
 
 # Convenience
 test.ipynb
+run-tests
 registration_template.ipynb

--- a/bionty/base/_public_ontology.py
+++ b/bionty/base/_public_ontology.py
@@ -393,7 +393,13 @@ class PublicOntology:
         if isinstance(values, str):
             values = [values]
 
-        field_values = self._df[str(field)]
+        # in bionty-base passed django fields do not resolve properly to a string
+        if str(field).startswith("FieldAttr"):
+            field_str = str(field).split(".")[-1][:-1]
+        else:
+            field_str = str(field)
+        field_values = self._df[str(field_str)]
+
         return validate(
             identifiers=values,
             field_values=field_values,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ readme = "README.md"
 dynamic = ["version", "description"]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "lamindb",


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2096

- We now infer a string representation if Bionty is running in `bionty-base` mode aka when `.public()` was accessed
This enables

```python
bt.Gene.public().validate(df["Gene Symbol"], field=bt.Gene.symbol, organism="human")
```

to work which would earlier error with `KeyError: 'FieldAttr(Gene.symbol)'`.