### PR TITLE
🧪 Test sources

### DIFF
--- a/bionty/models.py
+++ b/bionty/models.py
@@ -98,7 +98,7 @@ class Source(Record, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.source)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     entity: str = CharField(max_length=256, db_index=True)
     """Entity class name."""
     organism: str = CharField(max_length=64, db_index=True)
@@ -535,7 +535,7 @@ class Organism(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=64, db_index=True, default=None, unique=True)
     """Name of a organism, required field."""
     ontology_id: str | None = CharField(
@@ -635,7 +635,7 @@ class Gene(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=12, default=ids.gene)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     symbol: str | None = CharField(
         max_length=64, db_index=True, null=True, default=None
     )
@@ -755,7 +755,7 @@ class Protein(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=12, default=ids.protein)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str | None = CharField(max_length=256, db_index=True, null=True, default=None)
     """Unique name of a protein."""
     uniprotkb_id: str | None = CharField(
@@ -867,7 +867,7 @@ class CellMarker(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=12, default=ids.cellmarker)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=64, db_index=True)
     """Unique name of the cell marker."""
     synonyms: str | None = TextField(null=True, default=None)
@@ -983,7 +983,7 @@ class Tissue(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the tissue."""
     ontology_id: str | None = CharField(
@@ -1084,7 +1084,7 @@ class CellType(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the cell type."""
     ontology_id: str | None = CharField(
@@ -1186,7 +1186,7 @@ class Disease(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the disease."""
     ontology_id: str | None = CharField(
@@ -1289,7 +1289,7 @@ class CellLine(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the cell line."""
     ontology_id: str | None = CharField(
@@ -1394,7 +1394,7 @@ class Phenotype(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the phenotype."""
     ontology_id: str | None = CharField(
@@ -1497,7 +1497,7 @@ class Pathway(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the pathway."""
     ontology_id: str | None = CharField(
@@ -1605,7 +1605,7 @@ class ExperimentalFactor(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the experimental factor."""
     ontology_id: str | None = CharField(
@@ -1716,7 +1716,7 @@ class DevelopmentalStage(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the developmental stage."""
     ontology_id: str | None = CharField(
@@ -1820,7 +1820,7 @@ class Ethnicity(BioRecord, TracksRun, TracksUpdates):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(unique=True, max_length=8, default=ids.ontology)
-    """A universal id (hash of selected field)."""
+    """A universal id (base62-encoded hash of defining fields)."""
     name: str = CharField(max_length=256, db_index=True)
     """Name of the ethnicity."""
     ontology_id: str | None = CharField(

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,13 @@
+import shutil
+
+import lamindb_setup as ln_setup
+import pytest
+
+
+def pytest_sessionstart():
+    ln_setup.init(storage="./testdb", modules="bionty")
+
+
+def pytest_sessionfinish(session: pytest.Session):
+    shutil.rmtree("./testdb")
+    ln_setup.delete("testdb", force=True)

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -16,3 +16,21 @@ def test_add_source(setup_instance):
     assert new_source.name == "chebi"
     assert new_source.version == "2024-07-27"
     assert new_source.dataframe_artifact is not None
+
+
+def test_source_uids(setup_instance):
+    disease_ontology = bt.Source(
+        entity="bionty.Disease",
+        name="mondo",
+        version="2023-04-04",
+        _skip_validation=True,
+    )
+    assert disease_ontology.uid == "Hgw08Vk3"
+    phenotype_ontology = bt.Source(
+        entity="bionty.Phenotype",
+        name="hp",
+        version="2023-06-17",
+        organism="human",
+        _skip_validation=True,
+    )
+    assert phenotype_ontology.uid == "451W7iJS"

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -19,13 +19,6 @@ def test_add_source(setup_instance):
 
 
 def test_encode_uids(setup_instance):
-    gene = bt.Gene(
-        ensembl_gene_id="ENSG00000081059",
-        symbol="TCF7",
-        _skip_validation=True,
-    )
-    assert gene.uid == "7IkHKPl0ScQR"
-
     cell_type = bt.CellType(
         ontology_id="CL:0000084",
         _skip_validation=True,
@@ -46,6 +39,14 @@ def test_encode_uids(setup_instance):
         _skip_validation=True,
     )
     assert cell_marker.uid == "2dZ52W9noUDK"
+
+    gene = bt.Gene(
+        ensembl_gene_id="ENSG00000081059",
+        symbol="TCF7",
+        organism=bt.settings.organism,  # required
+        _skip_validation=True,
+    )
+    assert gene.uid == "7IkHKPl0ScQR"
 
     disease = bt.Source(
         entity="bionty.Disease",

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -18,19 +18,48 @@ def test_add_source(setup_instance):
     assert new_source.dataframe_artifact is not None
 
 
-def test_source_uids(setup_instance):
-    disease_ontology = bt.Source(
+def test_encode_uids(setup_instance):
+    gene = bt.Gene(
+        ensembl_gene_id="ENSG00000081059",
+        symbol="TCF7",
+        _skip_validation=True,
+    )
+    assert gene.uid == "7IkHKPl0ScQR"
+
+    cell_type = bt.CellType(
+        ontology_id="CL:0000084",
+        _skip_validation=True,
+    )
+    assert cell_type.uid == "22LvKd01"
+
+    organism = bt.Organism(
+        ontology_id="NCBITaxon:9606",
+        name="human",
+        _skip_validation=True,
+    )
+    assert organism.uid == "1dpCL6Td"
+
+    bt.settings.organism = "human"
+    cell_marker = bt.CellMarker(
+        name="test",
+        organism=bt.settings.organism,
+        _skip_validation=True,
+    )
+    assert cell_marker.uid == "2dZ52W9noUDK"
+
+    disease = bt.Source(
         entity="bionty.Disease",
         name="mondo",
         version="2023-04-04",
         _skip_validation=True,
     )
-    assert disease_ontology.uid == "Hgw08Vk3"
-    phenotype_ontology = bt.Source(
+    assert disease.uid == "Hgw08Vk3"
+
+    phenotype = bt.Source(
         entity="bionty.Phenotype",
         name="hp",
         version="2023-06-17",
         organism="human",
         _skip_validation=True,
     )
-    assert phenotype_ontology.uid == "451W7iJS"
+    assert phenotype.uid == "451W7iJS"

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -52,6 +52,7 @@ def test_encode_uids(setup_instance):
         entity="bionty.Disease",
         name="mondo",
         version="2023-04-04",
+        organism="all",
         _skip_validation=True,
     )
     assert disease.uid == "Hgw08Vk3"

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1,24 +1,19 @@
 import bionty as bt
-import lamindb_setup as ln_setup
-import pytest
 
 
-@pytest.fixture(scope="module")
-def setup_instance():
-    ln_setup.init(storage="./testdb", modules="bionty")
-    yield
-    ln_setup.delete("testdb", force=True)
+def test_public_synonym_mapping():
+    bt_result = bt.Gene.public().inspect(
+        ["ABC1", "TNFRSF4"], field="symbol", organism="human"
+    )
+    assert bt_result.synonyms_mapper == {"ABC1": "HEATR6"}
+
+    bt_result = bt.Gene.public().inspect(
+        ["ABC1", "TNFRSF4"], field="symbol", organism="human", inspect_synonyms=False
+    )
+    assert bt_result.synonyms_mapper == {}
 
 
-def test_add_source(setup_instance):
-    chebi_source = bt.Source.get(name="chebi", version="2024-07-27")
-    new_source = bt.Phenotype.add_source(chebi_source)
-    assert new_source.name == "chebi"
-    assert new_source.version == "2024-07-27"
-    assert new_source.dataframe_artifact is not None
-
-
-def test_encode_uids(setup_instance):
+def test_encode_uids():
     cell_type = bt.CellType(
         ontology_id="CL:0000084",
         _skip_validation=True,

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -1,0 +1,40 @@
+import bionty as bt
+
+
+def test_add_source():
+    chebi_source = bt.Source.get(name="chebi", version="2024-07-27")
+    new_source = bt.Phenotype.add_source(chebi_source)
+    assert new_source.name == "chebi"
+    assert new_source.version == "2024-07-27"
+    assert new_source.dataframe_artifact is not None
+
+
+def test_import_source():
+    record = bt.Ethnicity.from_source(ontology_id="HANCESTRO:0005").save()
+    parent = bt.Ethnicity.get(ontology_id="HANCESTRO:0004")
+    assert parent in record.parents.list()
+    parent.delete()
+
+    bt.Ethnicity.import_source()
+    parent = bt.Ethnicity.get(ontology_id="HANCESTRO:0004")
+    assert parent in record.parents.list()
+    record = bt.Ethnicity.get("7RNCY3yC")
+    assert record.parents.all().one().name == "South East Asian"
+    # the source.in_db should be set to True since we imported all the records
+    assert record.source.in_db is True
+
+
+def test_add_ontology_from_values():
+    bt.Ethnicity.filter().delete()
+    # .save() calls add_ontology() under the hood
+    bt.Ethnicity.from_values(
+        [
+            "HANCESTRO:0597",
+            "HANCESTRO:0006",
+        ],
+        field=bt.Ethnicity.ontology_id,
+    ).save()
+    record = bt.Ethnicity.get("7RNCY3yC")
+    assert record.parents.all().one().name == "South East Asian"
+    # the source.in_db should be set back to False since we deleted all records
+    assert record.source.in_db is False


### PR DESCRIPTION
This PR moves sources related tests from lamindb to `tests/core` here.