### PR TITLE
♻️ Refactor `sync_public_sources`

### DIFF
--- a/bionty/__init__.py
+++ b/bionty/__init__.py
@@ -121,6 +121,3 @@ if _check_instance_setup():
         Source,
         Tissue,
     )
-
-    # backward compat
-    PublicSource = Source

--- a/bionty/_biorecord.py
+++ b/bionty/_biorecord.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from . import ids
-from .models import Record
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -11,7 +10,9 @@ if TYPE_CHECKING:
     from .models import BioRecord
 
 
-def encode_uid(registry: type[Record], kwargs: dict):
+def encode_uid(registry: type[BioRecord], kwargs: dict):
+    from lamindb.models import Record
+
     if kwargs.get("uid") is not None:
         # if uid is passed, no encoding is needed
         return kwargs
@@ -81,17 +82,12 @@ def lookup2kwargs(record: BioRecord, *args, **kwargs) -> dict:
         bionty_kwargs = arg[0]._asdict()
 
     if len(bionty_kwargs) > 0:
-        # import bionty.base as bt_base
-
         # add organism and source
         organism_record = create_or_get_organism_record(
             registry=record.__class__, organism=kwargs.get("organism")
         )
         if organism_record is not None:
             bionty_kwargs["organism"] = organism_record
-        # public_ontology = getattr(bt_base, record.__class__.__name__)(
-        #     organism=organism_record.name if organism_record is not None else None
-        # )
         bionty_kwargs["source"] = get_source_record(
             registry=record.__class__,
             organism=organism_record,
@@ -109,6 +105,8 @@ def lookup2kwargs(record: BioRecord, *args, **kwargs) -> dict:
 def list_biorecord_models(schema_module: ModuleType):
     """List all BioRecord models in a given schema module."""
     import inspect
+
+    import lamindb as ln  # needed here
 
     from .models import BioRecord
 

--- a/bionty/base/_display_sources.py
+++ b/bionty/base/_display_sources.py
@@ -3,7 +3,6 @@ from lamin_utils import logger
 
 from bionty.base.dev._handle_sources import LAMINDB_INSTANCE_LOADED
 
-# from bionty.base.dev._io import load_yaml
 from ._settings import settings
 from .dev._handle_sources import parse_currently_used_sources
 

--- a/bionty/core/__init__.py
+++ b/bionty/core/__init__.py
@@ -6,8 +6,7 @@
    BioRecord
    StaticReference
    Settings
-   sync_all_sources_to_latest
-   set_latest_sources_as_currently_used
+   sync_public_sources
 """
 
 from lamindb_setup._check_setup import _check_instance_setup
@@ -18,7 +17,7 @@ from bionty.models import BioRecord, StaticReference
 
 from ._add_ontology import add_ontology
 from ._settings import Settings
-from ._source import (
-    set_latest_sources_as_currently_used,
-    sync_all_sources_to_latest,
-)
+from ._source import sync_public_sources
+
+# backward-compat
+sync_all_sources_to_latest = sync_public_sources

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -65,33 +65,29 @@ def test_add_ontology_from_values():
 
 
 def test_sync_public_sources():
+    bt.Source.get(name="ensembl", version="release-112", organism="mouse").delete()
+    source_gene_release_111 = bt.Source.get(
+        name="ensembl", version="release-111", organism="mouse"
+    )
+    source_gene_release_111.currently_used = True
+    source_gene_release_111.save()
+    bt.Source.get(name="cl", version="2024-08-16").delete()
+    source_ct_2024_05_15 = bt.Source.get(name="cl", version="2024-05-15")
+    source_ct_2024_05_15.currently_used = True
+    source_ct_2024_05_15.save()
+
+    # update_currently_used=False
+    bt.core.sync_public_sources()
     source_gene_release_112 = bt.Source.get(
         name="ensembl", version="release-112", organism="mouse"
     )
-    source_gene_release_111 = bt.Source.filter(
-        name="ensembl", version="release-111", organism="mouse"
-    ).update(currently_used=True)
-    source_ct_2024_08_16 = bt.Source.get(name="cl", version="2024-08-16")
-    source_ct_2024_05_15 = bt.Source.filter(name="cl", version="2024-05-15").update(
-        currently_used=True
-    )
-    source_gene_release_112.delete()
-    source_ct_2024_08_16.delete()
-
-    bt.core.sync_public_sources()
-    source_gene_release_112 = bt.Source.filter(
-        name="ensembl", version="release-112", organism="mouse"
-    ).one_or_none()
-    assert source_gene_release_112 is not None
     assert not source_gene_release_112.currently_used
     assert source_gene_release_111.currently_used
-    source_ct_2024_08_16 = bt.Source.filter(
-        name="cl", version="2024-08-16"
-    ).one_or_none()
-    assert source_ct_2024_08_16 is not None
+    source_ct_2024_08_16 = bt.Source.get(name="cl", version="2024-08-16")
     assert not source_ct_2024_08_16.currently_used
     assert source_ct_2024_05_15.currently_used
 
+    # update_currently_used=True
     bt.core.sync_public_sources(update_currently_used=True)
     source_gene_release_112 = bt.Source.filter(
         name="ensembl", version="release-112", organism="mouse"


### PR DESCRIPTION
- Rename `sync_all_sources_to_latest` → `sync_public_sources`
- Incorporated `set_latest_sources_as_currently_used` into `sync_public_sources`
- Test `sync_public_sources`
- Remove `source.set_as_currently_used()`, automatically takes care in `save`.