### PR TITLE
✨ Support custom source

### DIFF
--- a/bionty/base/_public_ontology.py
+++ b/bionty/base/_public_ontology.py
@@ -66,16 +66,17 @@ class PublicOntology:
             self._source = self._source_dict["name"]
             self._version = self._source_dict["version"]
 
-            self._set_file_paths()
-            self.include_id_prefixes = include_id_prefixes
-            self.include_rel = include_rel
-
         except (ValueError, KeyError) as e:
             if LAMINDB_INSTANCE_LOADED:
                 # to support StaticSource in lamindb
+                self._source_dict = {}
                 pass
             else:
                 raise e
+
+        self._set_file_paths()
+        self.include_id_prefixes = include_id_prefixes
+        self.include_rel = include_rel
 
         # df is only read into memory at the init to improve performance
         df = self._load_df()

--- a/bionty/base/_public_ontology.py
+++ b/bionty/base/_public_ontology.py
@@ -62,10 +62,6 @@ class PublicOntology:
                 organism=organism,
             )
 
-            self._organism = self._source_dict["organism"]
-            self._source = self._source_dict["name"]
-            self._version = self._source_dict["version"]
-
         except (ValueError, KeyError) as e:
             if LAMINDB_INSTANCE_LOADED:
                 # to support StaticSource in lamindb
@@ -73,6 +69,10 @@ class PublicOntology:
                 pass
             else:
                 raise e
+
+        self._organism = self._source_dict.get("organism")
+        self._source = self._source_dict.get("name")
+        self._version = self._source_dict.get("version")
 
         self._set_file_paths()
         self.include_id_prefixes = include_id_prefixes

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
+import pandas as pd
 from django.db import models
 from django.db.models import CASCADE, PROTECT
 from lamin_utils import logger
@@ -49,7 +51,10 @@ class StaticReference(PublicOntology):
         )
 
     def _load_df(self) -> DataFrame:
-        return self._source_record.dataframe_artifact.load(is_run_input=False)  # type:ignore
+        if self._source_record.dataframe_artifact_id:
+            return self._source_record.dataframe_artifact.load(is_run_input=False)
+        else:
+            return pd.DataFrame()
 
 
 def _sanitize_from_source_args(

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, overload
+from typing import Any, overload
 
 import numpy as np
 import pandas as pd
@@ -37,9 +36,6 @@ from ._shared_docstrings import doc_from_source
 from .base import PublicOntology
 from .base._public_ontology import InvalidParamError
 
-if TYPE_CHECKING:
-    from pandas import DataFrame
-
 
 class StaticReference(PublicOntology):
     def __init__(self, source_record: Source) -> None:
@@ -50,7 +46,7 @@ class StaticReference(PublicOntology):
             organism=source_record.organism,
         )
 
-    def _load_df(self) -> DataFrame:
+    def _load_df(self) -> pd.DataFrame:
         if self._source_record.dataframe_artifact_id:
             return self._source_record.dataframe_artifact.load(is_run_input=False)
         else:

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ def lint(session: nox.Session) -> None:
 @nox.session
 @nox.parametrize("group", ["bionty-base", "bionty-core", "bionty-docs"])
 def build(session: nox.Session, group: str):
-    branch = "main" if IS_PR else "release"  # point back to "release"
+    branch = "custom-source" if IS_PR else "release"  # point back to "release"
     install_lamindb(session, branch=branch)
     run(session, "uv pip install --system wetlab")
     session.run(*"uv pip install --system -e .[dev]".split())


### PR DESCRIPTION
This PR supports adding custom public source to `source.dataframe_artifact`. This source can then be used as any other bionty public sources in `.from_values`, `validate`, etc.