### PR TITLE
🚸 Make the default organism `"human"` instead of `None`

### DIFF
--- a/bionty/_organism.py
+++ b/bionty/_organism.py
@@ -25,7 +25,7 @@ def create_or_get_organism_record(
         from .models import Organism
 
         if organism is None and settings.organism is not None:
-            logger.debug(f"using global setting organism = {settings.organism.name}")
+            logger.warning(f"using default organism = {settings.organism.name}")
             return settings.organism
 
         if isinstance(organism, Organism):

--- a/bionty/core/_settings.py
+++ b/bionty/core/_settings.py
@@ -8,23 +8,21 @@ from bionty.models import Organism
 class Settings:
     """Settings.
 
-    Directly use `.settings` rather than instantiating this class yourself.
+    Directly use `bt.settings` rather than instantiating this class yourself.
     """
 
     def __init__(self):
-        self._organism = None
+        self._organism = "human"
 
     @property
     def organism(self) -> Organism | None:
-        """Default organism argument (default `None`).
+        """Default organism argument (default `"human"`).
 
-        Default record to use when `organism` argument is required in `lamindb` functionality.
-
-        Only takes effect if explicitly set!
+        Default organism to use in cases of ambiguity. For instance, gene symbols are duplicated across organisms and need to be disambiguated.
 
         Examples:
-            >>> bionty.settings.organism = "mouse"
-            ✅ set organism: Organism(id=vado, name=mouse, taxon_id=10090, scientific_name=mus_musculus, updated_at=2023-07-21 11:37:08, source_id=CXWj, created_by_id=DzTjkKse) # noqa
+
+            bionty.settings.organism = "mouse"
         """
         return self._organism
 

--- a/bionty/core/_settings.py
+++ b/bionty/core/_settings.py
@@ -24,6 +24,8 @@ class Settings:
 
             bionty.settings.organism = "mouse"
         """
+        if isinstance(self._organism, str):
+            self.organism = self._organism  # type: ignore
         return self._organism
 
     @organism.setter
@@ -46,7 +48,6 @@ class Settings:
                 organism = organisms[0]
             if organism._state.adding:  # type:ignore
                 organism.save()  # type:ignore
-            logger.debug(f"set organism: {organism}")
             self._organism = organism
 
 


### PR DESCRIPTION
In cases in which a user isn't careful enough to specify anything and uses gene symbols, they usually don't care about whether a symbol is linked to one species or another.

Using `"human"` as a default here allows to eliminate much legacy logic in `lamindb`.

- https://github.com/laminlabs/lamindb/pull/2665