### PR TITLE
🐛 Fix downloading old Ensembl versions

### DIFF
--- a/bionty/base/_public_ontology.py
+++ b/bionty/base/_public_ontology.py
@@ -76,6 +76,7 @@ class PublicOntology:
         self._source = self._source_dict.get("name") or source
         self._version = self._source_dict.get("version") or version
 
+        self._get_url()
         self._set_file_paths()
         self.include_id_prefixes = include_id_prefixes
         self.include_rel = include_rel
@@ -240,18 +241,13 @@ class PublicOntology:
             )
             _ = url_download(url, localpath)
 
+    def _get_url(self):
+        """Get the url of the source."""
+        self._url: str = self._source_dict.get("url", "")
+
     @check_datasetdir_exists
     def _set_file_paths(self) -> None:
-        """Sets version, database and URL attributes for passed database and requested version."""
-        self._url: str = self._source_dict.get("url", "")
-        if (
-            not self._url
-            and self.__class__.__name__ == "Organism"
-            and self._source == "ensembl"
-            and self._version.startswith("release-")
-        ):
-            self._url = f"https://ftp.ensembl.org/pub/{self._version}/species_EnsemblVertebrates.txt"
-
+        """Sets local file paths."""
         # parquet file name, ontology source file name
         self._parquet_filename, self._ontology_filename = encode_filenames(
             organism=self.organism,

--- a/bionty/base/_public_ontology.py
+++ b/bionty/base/_public_ontology.py
@@ -244,6 +244,13 @@ class PublicOntology:
     def _set_file_paths(self) -> None:
         """Sets version, database and URL attributes for passed database and requested version."""
         self._url: str = self._source_dict.get("url", "")
+        if (
+            not self._url
+            and self.__class__.__name__ == "Organism"
+            and self._source == "ensembl"
+            and self._version.startswith("release-")
+        ):
+            self._url = f"https://ftp.ensembl.org/pub/{self._version}/species_EnsemblVertebrates.txt"
 
         # parquet file name, ontology source file name
         self._parquet_filename, self._ontology_filename = encode_filenames(

--- a/bionty/base/entities/_gene.py
+++ b/bionty/base/entities/_gene.py
@@ -150,14 +150,12 @@ class EnsemblGene:
         """
         self._import()
 
-        try:
-            self._organism = (
-                Organism(version=version, taxa=taxa).lookup().dict().get(organism)  # type:ignore
-            )
-        except Exception:
-            self._organism = (
-                Organism(taxa=taxa).lookup().dict().get(organism)  # type:ignore
-            )
+        self._organism = (
+            Organism(source="ensembl", version=version, taxa=taxa)  # type:ignore
+            .lookup()
+            .dict()
+            .get(organism)
+        )
 
         # Determine port based on taxa
         self._port = 4157 if taxa == "plants" else 3306

--- a/bionty/base/entities/_organism.py
+++ b/bionty/base/entities/_organism.py
@@ -48,6 +48,15 @@ class Organism(PublicOntology):
             taxa = kwargs.pop("organism")
         super().__init__(organism=taxa, source=source, version=version, **kwargs)
 
+    def _get_url(self):
+        super()._get_url()
+        if (
+            not self._url
+            and self._source == "ensembl"
+            and self._version.startswith("release-")
+        ):
+            self._url = f"https://ftp.ensembl.org/pub/{self._version}/species_EnsemblVertebrates.txt"
+
     def _load_df(self) -> pd.DataFrame:
         if self.source == "ensembl":
             if not self._local_parquet_path.exists():

--- a/tests/base/entities/test_gene.py
+++ b/tests/base/entities/test_gene.py
@@ -89,3 +89,8 @@ def test_old_ensembl_version():
         source="ensembl", organism="mouse", version="release-102"
     )
     assert "ENSMUSG00000021745" in gene_ontology_102.df()["ensembl_gene_id"].values
+
+    gene_ontology_112 = bt_base.Gene(
+        source="ensembl", organism="mouse", version="release-112"
+    )
+    assert "ENSMUSG00000021745" not in gene_ontology_112.df()["ensembl_gene_id"].values

--- a/tests/base/entities/test_gene.py
+++ b/tests/base/entities/test_gene.py
@@ -82,3 +82,10 @@ def test_ensemblgene_map_legacy_ids():
         ambiguous={},
         unmapped=[],
     )
+
+
+def test_old_ensembl_version():
+    gene_ontology_102 = bt_base.Gene(
+        source="ensembl", organism="mouse", version="release-102"
+    )
+    assert "ENSMUSG00000021745" in gene_ontology_102.df()["ensembl_gene_id"].values


### PR DESCRIPTION
This PR fixes the download of old Ensembl genes.

If you have been using Ensembl versions below 108, please clear the cached ontology source files:

```python
import bionty as bt
import shutil

shutil.rmtree(bt.base.settings.dynamicdir)
```

## Background

A bug was introduced in the recent PR leading up to bionty 1.3.0:

- https://github.com/laminlabs/bionty/pull/236

Note that it doesn't affect versions that are present in [source.yaml](https://github.com/laminlabs/bionty/blob/main/bionty/base/sources.yaml).

