### PR TITLE
🎨 Allow using public reference without prefix filters

### DIFF
--- a/bionty/base/_public_ontology.py
+++ b/bionty/base/_public_ontology.py
@@ -49,9 +49,11 @@ class PublicOntology:
         include_rel: str | None = None,
         entity: str | None = None,
         ols_supported: bool = True,
+        filter_prefix: bool = True,
     ):
         self._entity = entity or self.__class__.__name__
         self._ols_supported = ols_supported
+        self._filter_prefix = filter_prefix
 
         # search in all available sources to get url
         try:
@@ -339,14 +341,15 @@ class PublicOntology:
             bt_base.Gene().df()
         """
         if "ontology_id" in self._df.columns:
-            # Filter ontology_id by source prefix
-            filtered_df = self._df[
-                self._df["ontology_id"]
-                .str.upper()
-                .str.startswith(f"{self._source.upper()}:")
-            ].set_index("ontology_id")
-            if not filtered_df.empty:
-                return filtered_df
+            if self._filter_prefix:
+                # Filter ontology_id by source prefix
+                filtered_df = self._df[
+                    self._df["ontology_id"]
+                    .str.upper()
+                    .str.startswith(f"{self._source.upper()}:")
+                ].set_index("ontology_id")
+                if not filtered_df.empty:
+                    return filtered_df
             return self._df.set_index("ontology_id")
         else:
             return self._df

--- a/bionty/base/sources.yaml
+++ b/bionty/base/sources.yaml
@@ -80,7 +80,7 @@ CellType:
 Tissue:
   uberon:
     all:
-      latest-version: 2025-05-28
+      latest-version: 2024-08-07
       url: http://purl.obolibrary.org/obo/uberon/releases/{version}/uberon.owl
     name: Uberon multi-species anatomy ontology
     website: http://obophenotype.github.io/uberon

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -51,6 +51,7 @@ class StaticReference(PublicOntology):
 
     def _load_df(self) -> pd.DataFrame:
         if self._source_record.dataframe_artifact_id:
+            self._filter_prefix = False
             return self._source_record.dataframe_artifact.load(is_run_input=False)
         else:
             return pd.DataFrame()

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -240,12 +240,10 @@ def test_import_source_update_records():
 
 
 def test_import_source_no_prefix_filter():
-    from bionty.base._ontology import Ontology
-
     efo_public = bt.base.ExperimentalFactor(version="3.78.0")
-    efo_ontology = Ontology(bt.base.settings.dynamicdir / efo_public._ontology_filename)
-    efo_ontology_df = efo_ontology.to_df()
-    # efo_ontology_df.shape()
+    efo_ontology_df = efo_public.to_pronto().to_df(include_id_prefixes=None)
+    assert efo_ontology_df.shape[0] == 66971
+    assert efo_ontology_df.index.str.startswith("EFO:").sum() == 18229
     source = bt.ExperimentalFactor.add_source(source="efo", df=efo_ontology_df)
     bt.ExperimentalFactor.import_source(source=source)
     assert bt.ExperimentalFactor.filter().count() == 66971

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -237,3 +237,15 @@ def test_import_source_update_records():
     record_wo_artifact = bt.CellType.get(ontology_id="CL:0000409")
     assert record_wo_artifact.source == source2
     assert record_wo_artifact.name != record_wo_artifact_name
+
+
+def test_import_source_no_prefix_filter():
+    from bionty.base._ontology import Ontology
+
+    efo_public = bt.base.ExperimentalFactor(version="3.78.0")
+    efo_ontology = Ontology(bt.base.settings.dynamicdir / efo_public._ontology_filename)
+    efo_ontology_df = efo_ontology.to_df()
+    # efo_ontology_df.shape()
+    source = bt.ExperimentalFactor.add_source(source="efo", df=efo_ontology_df)
+    bt.ExperimentalFactor.import_source(source=source)
+    assert bt.ExperimentalFactor.filter().count() == 66971


### PR DESCRIPTION
This PR allows users to configure generate reference table without filtering for prefix.

```python
efo_public = bt.base.ExperimentalFactor(version="3.78.0")
efo_ontology_df = efo_public.to_pronto().to_df(include_id_prefixes=None)
assert efo_ontology_df.shape[0] == 66971
assert efo_ontology_df.index.str.startswith("EFO:").sum() == 18229
source = bt.ExperimentalFactor.add_source(source="efo", df=efo_ontology_df)
bt.ExperimentalFactor.import_source(source=source)
assert bt.ExperimentalFactor.filter().count() == 66971
```