### PR TITLE
🚑 Downgrade sources versions in sources.yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.pre-filter.outputs.matrix)}}
-    timeout-minutes: 20
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.pre-filter.outputs.matrix)}}
-    timeout-minutes: 5
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@v4
         with:

--- a/bionty/base/entities/_disease.py
+++ b/bionty/base/entities/_disease.py
@@ -23,7 +23,9 @@ MondoVersions = Literal[
     "2023-04-04",
 ]
 
-DOIDVersions = Literal["2024-05-29", "2024-01-31", "2023-03-31", "2023-01-30"]
+DOIDVersions = Literal[
+    "2025-05-30", "2024-05-29", "2024-01-31", "2023-03-31", "2023-01-30"
+]
 
 
 @_doc_params(doc_entities=doc_entites)

--- a/bionty/base/sources.yaml
+++ b/bionty/base/sources.yaml
@@ -73,7 +73,7 @@ CellLine:
 CellType:
   cl:
     all:
-      latest-version: 2025-04-10
+      latest-version: 2024-08-16
       url: http://purl.obolibrary.org/obo/cl/releases/{version}/cl.owl
     name: Cell Ontology
     website: https://obophenotype.github.io/cell-ontology
@@ -93,7 +93,7 @@ Disease:
     website: https://mondo.monarchinitiative.org
   doid:
     human:
-      latest-version: 2025-05-30
+      latest-version: 2024-05-29
       url: http://purl.obolibrary.org/obo/doid/releases/{version}/doid.obo
     name: Human Disease Ontology
     website: https://disease-ontology.org
@@ -106,20 +106,20 @@ Disease:
 ExperimentalFactor:
   efo:
     all:
-      latest-version: 3.78.0
+      latest-version: 3.70.0
       url: http://www.ebi.ac.uk/efo/releases/v{version}/efo.owl
     name: The Experimental Factor Ontology
     website: https://bioportal.bioontology.org/ontologies/EFO
 Phenotype:
   pato:
     all:
-      latest-version: 2025-05-14
+      latest-version: 2024-03-28
       url: http://purl.obolibrary.org/obo/pato/releases/{version}/pato.owl
     name: Phenotype And Trait Ontology
     website: https://github.com/pato-ontology/pato
   hp:
     human:
-      latest-version: 2025-05-06
+      latest-version: 2024-04-26
       url: https://github.com/obophenotype/human-phenotype-ontology/releases/download/v{version}/hp.owl
     name: Human Phenotype Ontology
     website: https://hpo.jax.org
@@ -132,7 +132,7 @@ Phenotype:
 Pathway:
   go:
     all:
-      latest-version: 2024-11-03
+      latest-version: 2024-06-17
       url: http://purl.obolibrary.org/obo/go/releases/{version}/extensions/go-plus.owl
     name: Gene Ontology
     website: http://geneontology.org
@@ -152,7 +152,7 @@ BFXPipeline:
 Drug:
   dron:
     all:
-      latest-version: 2025-04-18
+      latest-version: 2024-08-05
       url: http://purl.obolibrary.org/obo/dron/releases/{version}/dron.owl
     name: Drug Ontology
     website: https://bioportal.bioontology.org/ontologies/DRON
@@ -165,20 +165,20 @@ Drug:
 DevelopmentalStage:
   hsapdv:
     human:
-      latest-version: 2025-01-23
+      latest-version: 2024-05-28
       url: https://github.com/obophenotype/developmental-stage-ontologies/releases/download/v{version}/hsapdv.owl
     name: Human Developmental Stages
     website: https://github.com/obophenotype/developmental-stage-ontologies/wiki/HsapDv
   mmusdv:
     mouse:
-      latest-version: 2025-01-23
+      latest-version: 2024-05-28
       url: https://github.com/obophenotype/developmental-stage-ontologies/releases/download/v{version}/mmusdv.owl
     name: Mouse Developmental Stages
     website: https://github.com/obophenotype/developmental-stage-ontologies/wiki/MmusDv
 Ethnicity:
   hancestro:
     human:
-      latest-version: 2025-04-01
+      latest-version: 3.0
       url: http://purl.obolibrary.org/obo/hancestro/releases/{version}/hancestro.owl
     name: Human Ancestry Ontology
     website: https://github.com/EBISPOT/hancestro


### PR DESCRIPTION
This pull request reverts the version upgrades from https://github.com/laminlabs/bionty/pull/259. 

Also updated `DOIDVersions` in `_disease.py` to include the new version "2025-05-30" for later.