### PR TITLE
♻️ Remove pronto warning filters from __init__.py

### DIFF
--- a/bionty/__init__.py
+++ b/bionty/__init__.py
@@ -91,17 +91,6 @@ Submodules:
 
 __version__ = "1.6.0"
 
-
-from importlib.util import find_spec
-
-if find_spec("pronto"):
-    import warnings
-
-    from pronto.utils.warnings import NotImplementedWarning, SyntaxWarning
-
-    warnings.filterwarnings("ignore", category=SyntaxWarning)
-    warnings.filterwarnings("ignore", category=NotImplementedWarning)
-
 from lamindb_setup._check_setup import _check_instance_setup
 
 from . import _biorecord, base, ids


### PR DESCRIPTION
This PR removes the import and warning filters for the `pronto` package in `bionty/__init__.py`, reducing the redundancy. 

For example, https://github.com/laminlabs/bionty/blob/f8fe6edabdd2ff8a66135aed0ba87c81d861e9c0/bionty/base/_ontology.py#L18 should be already sufficient. 