### PR TITLE
🔈 Added loggings to `Ontology.to_df()`

### DIFF
--- a/bionty/base/_ontology.py
+++ b/bionty/base/_ontology.py
@@ -90,12 +90,12 @@ try:
                 - synonyms: A pipe-separated string of exact synonyms (None if no synonyms).
                 - parents: A list of parent term IDs, including superclasses and optionally the specified relationship.
             """
-            logger.hint(f"Starting ontology to_df() conversion for source: {source}")
+            logger.info(f"starting ontology to_df() conversion for source: {source}")
 
             def filter_include_id_prefixes(terms: pronto.ontology._OntologyTerms):  # type:ignore
                 if include_id_prefixes and source in list(include_id_prefixes.keys()):
-                    logger.hint(
-                        f"Filtering terms by ID prefixes for source {source}: {include_id_prefixes[source]}"
+                    logger.info(
+                        f"filtering terms by ID prefixes for source {source}: {include_id_prefixes[source]}"
                     )
                     return list(
                         filter(
@@ -107,7 +107,6 @@ try:
                         )
                     )
                 else:
-                    logger.hint("No ID prefix filtering applied")
                     return terms
 
             if source is not None:
@@ -119,10 +118,10 @@ try:
             else:
                 prefix_list = None
 
-            logger.hint("Filtering terms by ID prefixes...")
+            logger.info("filtering terms by ID prefixes...")
             filtered_terms = filter_include_id_prefixes(self.terms())
 
-            logger.hint("Processing individual terms...")
+            logger.info("processing individual terms...")
             df_values = []
 
             processed_count = 0
@@ -130,8 +129,8 @@ try:
 
             for i, term in enumerate(filtered_terms):
                 if i % log_interval == 0 and i > 0:
-                    logger.hint(
-                        f"Processed {i}/{len(filtered_terms)} terms ({i / len(filtered_terms) * 100:.1f}%)"
+                    logger.info(
+                        f"\tprocessed {i}/{len(filtered_terms)} terms ({i / len(filtered_terms) * 100:.1f}%)"
                     )
 
                 # skip terms without id or name
@@ -185,13 +184,13 @@ try:
                 )
                 processed_count += 1
 
-            logger.hint(f"Processed {processed_count} terms")
+            logger.success(f"processed {processed_count} terms")
 
             df = pd.DataFrame(
                 df_values,
                 columns=["ontology_id", "name", "definition", "synonyms", "parents"],
             )
-            logger.hint(f"Created DataFrame with {len(df)} rows")
+            logger.success(f"created DataFrame with {len(df)} rows")
 
             df["ontology_id"] = [
                 i.replace(self._prefix, "").replace("_", ":") for i in df["ontology_id"]
@@ -203,7 +202,7 @@ try:
 
             # needed to avoid erroring in .lookup()
             df["name"] = df["name"].fillna("")
-            logger.hint("Conversion completed")
+            logger.success("conversion completed")
 
             return df.set_index("ontology_id")
 

--- a/bionty/base/_ontology.py
+++ b/bionty/base/_ontology.py
@@ -90,7 +90,7 @@ try:
                 - synonyms: A pipe-separated string of exact synonyms (None if no synonyms).
                 - parents: A list of parent term IDs, including superclasses and optionally the specified relationship.
             """
-            logger.info(f"starting ontology to_df() conversion for source: {source}")
+            logger.info(f"starting ontology `to_df()` conversion for source: {source}")
 
             def filter_include_id_prefixes(terms: pronto.ontology._OntologyTerms):  # type:ignore
                 if include_id_prefixes and source in list(include_id_prefixes.keys()):
@@ -129,8 +129,9 @@ try:
 
             for i, term in enumerate(filtered_terms):
                 if i % log_interval == 0 and i > 0:
+                    print("  ", end="")
                     logger.info(
-                        f"\tprocessed {i}/{len(filtered_terms)} terms ({i / len(filtered_terms) * 100:.1f}%)"
+                        f"Processed {i}/{len(filtered_terms)} terms ({i / len(filtered_terms) * 100:.1f}%)"
                     )
 
                 # skip terms without id or name

--- a/bionty/base/_ontology.py
+++ b/bionty/base/_ontology.py
@@ -16,7 +16,9 @@ def import_pronto():
 
         import pronto  # type: ignore
 
-        warnings.filterwarnings("ignore", category=pronto.warnings.ProntoWarning)
+        if logger._verbosity <= 3:
+            warnings.filterwarnings("ignore", category=pronto.warnings.ProntoWarning)
+
         return pronto
     except ImportError as exc:
         raise ImportError(


### PR DESCRIPTION
Added hint level logging messages to the `to_df()` function.

The changes aim to provide better visibility into the execution flow.
E.g. when hint verbosity is on, you would see this when updating an ontology source: 

```
• Processing... Phenotype            pato       2025-05-14   all
• downloading Phenotype ontology source file...
• downloading Phenotype source file from: http://purl.obolibrary.org/obo/pato/releases/2025-05-14/pato.owl
• Starting ontology to_df() conversion for source: pato
• Filtering terms by ID prefixes...
• No ID prefix filtering applied
• Processing individual terms...
• Processed 431/8625 terms (5.0%)
• Processed 862/8625 terms (10.0%)
• Processed 1293/8625 terms (15.0%)
• Processed 1724/8625 terms (20.0%)
• Processed 2155/8625 terms (25.0%)
• Processed 2586/8625 terms (30.0%)
• Processed 3017/8625 terms (35.0%)
• Processed 3448/8625 terms (40.0%)
• Processed 3879/8625 terms (45.0%)
• Processed 4310/8625 terms (50.0%)
• Processed 4741/8625 terms (55.0%)
• Processed 5172/8625 terms (60.0%)
• Processed 5603/8625 terms (65.0%)
• Processed 6034/8625 terms (70.0%)
• Processed 6465/8625 terms (75.0%)
• Processed 6896/8625 terms (80.0%)
• Processed 7327/8625 terms (85.0%)
• Processed 7758/8625 terms (89.9%)
• Processed 8189/8625 terms (94.9%)
• Processed 8620/8625 terms (99.9%)
• Processed 8522 terms
• Created DataFrame with 8522 rows
• Conversion completed
```
