### PR TITLE
♻️ Adapt to renaming of `UPath.synchronize()` to `UPath.synchronize_to()`

### DIFF
--- a/bionty/base/dev/_io.py
+++ b/bionty/base/dev/_io.py
@@ -125,10 +125,11 @@ def s3_bionty_assets(
         return localpath
     # this is needed unfortunately because s3://bionty-assets doesn't have ListObjectsV2
     # for anonymous users. And ListObjectsV2 is triggred inside .synchronize if no cache is present
+    # todo: check if this is still needed
     parent_path = remote_path.parent.path.rstrip("/")
     remote_path.fs.dircache[parent_path] = [remote_stat.as_info()]
     # synchronize the remote path
-    remote_path.synchronize(localpath, error_no_origin=False, print_progress=True)
+    remote_path.synchronize_to(localpath, error_no_origin=False, print_progress=True)
     # clean the artificial cache
     del remote_path.fs.dircache[parent_path]
 


### PR DESCRIPTION
https://github.com/laminlabs/lamindb-setup/pull/1089

the tests fail due to wrong `lamindb-setup` being installed for now in the CI.