### PR TITLE
🐛 Fix typos of `include_id_prefixes`

### DIFF
--- a/bionty/base/entities/_cellline.py
+++ b/bionty/base/entities/_cellline.py
@@ -40,6 +40,6 @@ class CellLine(PublicOntology):
             source=source,
             version=version,
             organism=organism,
-            include_id_prefixes={"clo:": ["CLO"]},
+            include_id_prefixes={"clo": ["CLO:"]},
             **kwargs,
         )

--- a/bionty/base/entities/_celltype.py
+++ b/bionty/base/entities/_celltype.py
@@ -42,6 +42,6 @@ class CellType(PublicOntology):
             source=source,
             version=version,
             organism=organism,
-            include_id_prefixes={"cl": ["CL"]},
+            include_id_prefixes={"cl": ["CL:"]},
             **kwargs,
         )

--- a/bionty/base/entities/_developmentalstage.py
+++ b/bionty/base/entities/_developmentalstage.py
@@ -30,7 +30,7 @@ class DevelopmentalStage(PublicOntology):
             source=source,
             version=version,
             organism=organism,
-            include_id_prefixes={"hsapdv:": ["HsapDv"], "mmusdv:": ["MmusDv"]},
+            include_id_prefixes={"hsapdv": ["HsapDv:"], "mmusdv": ["MmusDv:"]},
             include_rel="part_of",
             **kwargs,
         )

--- a/bionty/base/entities/_disease.py
+++ b/bionty/base/entities/_disease.py
@@ -64,6 +64,6 @@ class Disease(PublicOntology):
             source=source,
             version=version,
             organism=organism,
-            include_id_prefixes={"mondo:": ["MONDO"]},
+            include_id_prefixes={"mondo": ["MONDO:"]},
             **kwargs,
         )

--- a/bionty/base/entities/_drug.py
+++ b/bionty/base/entities/_drug.py
@@ -43,6 +43,6 @@ class Drug(PublicOntology):
             source=source,
             version=version,
             organism=organism,
-            include_id_prefixes={"dron:": ["DRON"]},
+            include_id_prefixes={"dron": ["DRON:"]},
             **kwargs,
         )

--- a/bionty/base/entities/_ethnicity.py
+++ b/bionty/base/entities/_ethnicity.py
@@ -30,6 +30,6 @@ class Ethnicity(PublicOntology):
             source=source,
             version=version,
             organism=organism,
-            include_id_prefixes={"hancestro:": ["HANCESTRO"]},
+            include_id_prefixes={"hancestro": ["HANCESTRO:"]},
             **kwargs,
         )

--- a/bionty/base/entities/_phenotype.py
+++ b/bionty/base/entities/_phenotype.py
@@ -55,10 +55,10 @@ class Phenotype(PublicOntology):
             version=version,
             organism=organism,
             include_id_prefixes={
-                "hp:": ["HP"],
-                "mp:": ["MP"],  # mp might require an exclusion prefix for mpath
-                "zp:": ["ZP"],
-                "pato:": ["PATO"],
+                "hp": ["HP:"],
+                "mp": ["MP:"],  # mp might require an exclusion prefix for mpath
+                "zp": ["ZP:"],
+                "pato": ["PATO:"],
             },
             **kwargs,
         )

--- a/bionty/base/entities/_tissue.py
+++ b/bionty/base/entities/_tissue.py
@@ -42,7 +42,7 @@ class Tissue(PublicOntology):
             source=source,
             version=version,
             organism=organism,
-            include_id_prefixes={"uberon": ["UBERON"]},
+            include_id_prefixes={"uberon": ["UBERON:"]},
             include_rel="part_of",
             **kwargs,
         )


### PR DESCRIPTION
Typos were introduced in this previous PR: https://github.com/laminlabs/bionty/pull/259