### PR TITLE
⬆️ Support Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -53,14 +53,14 @@ jobs:
       matrix: ${{fromJson(needs.pre-filter.outputs.matrix)}}
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: cache pre-commit
         uses: actions/cache@v4
@@ -115,11 +115,11 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install coverage dependencies
         run: |

--- a/.github/workflows/update_ontologies.yml
+++ b/.github/workflows/update_ontologies.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install Bionty
         run: pip install .[dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "bionty"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 authors = [{name = "Lamin Labs", email = "open-source@lamin.ai"}]
 readme = "README.md"
 dynamic = ["version", "description"]
@@ -14,9 +14,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "lamindb>=1.12a1",
+    "lamindb>=1.12.1",
     "lamindb_setup>=0.81.2",
     "lamin_utils>=0.13.9",
     "requests",


### PR DESCRIPTION
The docs are also running with 3.14 now and this might cause further issues:

```
Warning, treated as error:
/home/runner/work/bionty/bionty/bionty/base/entities/_gene.py:docstring of bionty.base.entities._gene.Gene:9:Unexpected indentation.
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.14.0/x64/bin/lndocs", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/lndocs/__main__.py", line 744, in main
    remove_lines_with_db_args(
    ~~~~~~~~~~~~~~~~~~~~~~~~~^
        Path(args.site) / generated.with_suffix(".html").name
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/lndocs/__main__.py", line 34, in remove_lines_with_db_args
    with open(path) as f:
         ~~~~^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '_build/html/bionty.cellline.html'
```