### PR TITLE
♻️ Passing kwargs to from_source no longer recognize synonyms

### DIFF
--- a/bionty/models.py
+++ b/bionty/models.py
@@ -562,6 +562,9 @@ class BioRecord(SQLRecord, HasParents, CanCurate):
             # Create a record by passing a field value:
             record = bt.Gene.from_source(symbol="TCF7", organism="human")
 
+            # Create a record by passing a synonym:
+            record = bt.Gene.from_source("TCF-1", organism="human")
+
             # Create a record from non-default source:
             source = bt.Source.get(entity="CellType", source="cl", version="2022-08-16")
             record = bt.CellType.from_source(name="T cell", source=source)
@@ -595,11 +598,23 @@ class BioRecord(SQLRecord, HasParents, CanCurate):
                 if existing_records.exists():
                     results = existing_records.list()
                 else:
-                    from lamindb.models._from_values import create_records_from_source
+                    from lamindb.models._from_values import (
+                        create_records_from_source,
+                        get_organism_record_from_field,
+                    )
+
+                    field = getattr(cls, key)
+
+                    # get the organism record
+                    organism_record = get_organism_record_from_field(
+                        field, kwargs.get("organism"), values=[value]
+                    )
+                    if organism_record is not None:
+                        kwargs["organism"] = organism_record
 
                     results, _ = create_records_from_source(
                         pd.Index([value]),
-                        field=getattr(cls, key),
+                        field=field,
                         **kwargs,
                         inspect_synonyms=False,
                     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,10 +16,7 @@ def lint(session: nox.Session) -> None:
 @nox.session
 @nox.parametrize("group", ["bionty-base", "bionty-core", "bionty-docs"])
 def build(session: nox.Session, group: str):
-    branch = (
-        "main" if IS_PR else "main"
-    )  # point to "main" for PRs, to "release" for main
-    install_lamindb(session, branch=branch)
+    install_lamindb(session, branch="from-source")
     run(session, "uv pip install --system wetlab")
     session.run(*"uv pip install --system -e .[dev]".split())
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,10 +16,10 @@ def lint(session: nox.Session) -> None:
 @nox.session
 @nox.parametrize("group", ["bionty-base", "bionty-core", "bionty-docs"])
 def build(session: nox.Session, group: str):
-    # branch = (
-    #     "main" if IS_PR else "main"
-    # )  # point to "main" for PRs, to "release" for main
-    install_lamindb(session, branch="from-source")
+    branch = (
+        "main" if IS_PR else "main"
+    )  # point to "main" for PRs, to "release" for main
+    install_lamindb(session, branch=branch)
     run(session, "uv pip install --system wetlab")
     session.run(*"uv pip install --system -e .[dev]".split())
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,9 @@ def lint(session: nox.Session) -> None:
 @nox.session
 @nox.parametrize("group", ["bionty-base", "bionty-core", "bionty-docs"])
 def build(session: nox.Session, group: str):
+    # branch = (
+    #     "main" if IS_PR else "main"
+    # )  # point to "main" for PRs, to "release" for main
     install_lamindb(session, branch="from-source")
     run(session, "uv pip install --system wetlab")
     session.run(*"uv pip install --system -e .[dev]".split())

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -6,24 +6,39 @@ from bionty.models import DoesNotExist, InvalidArgument
 
 
 def test_from_source():
+    # test passing organism
     record = bt.Gene.from_source(symbol="BRCA2", organism="human")
     assert record.ensembl_gene_id == "ENSG00000139618"
 
+    # name is not found
     with pytest.raises(
-        DoesNotExist, match=r"No record found in source for the given field value"
+        DoesNotExist,
+        match=r"no CellType found in source for the given field value: name='T-cellx'",
     ):
         bt.CellType.from_source(name="T-cellx")
 
+    # multiple fields passed
     with pytest.raises(
         InvalidArgument,
         match=r"Only one field can be passed to generate records from source",
     ):
         bt.CellType.from_source(name="T cell", ontology_id="CL:0000084")
 
+    # no field passed
     with pytest.raises(
         InvalidArgument, match=r"No field passed to generate records from source"
     ):
         bt.CellType.from_source()
+
+    # passing a synonym via name= doesn't work
+    with pytest.raises(
+        DoesNotExist,
+        match=r"no CellType found in source for the given field value: name='T-cell'",
+    ):
+        bt.CellType.from_source(name="T-cell")
+
+    # passing a synonym as positional argument works
+    bt.CellType.from_source("T-cell")
 
 
 def test_get_source_record():


### PR DESCRIPTION
https://laminlabs.slack.com/archives/C04MU979KD3/p1762525130631669

Needs: https://github.com/laminlabs/lamindb/pull/3273

Before | After
--- | ---
<img width="724" height="549" alt="Screenshot 2025-11-10 at 17 16 10" src="https://github.com/user-attachments/assets/21046955-322c-4da3-b19b-9b1e94e2ac6f" /> | <img width="820" height="725" alt="Screenshot 2025-11-10 at 17 13 48" src="https://github.com/user-attachments/assets/38879744-be9c-4b48-9c46-0cd35a63e2b3" />
