### PR TITLE
🎨 More robust `add_source`

### DIFF
--- a/bionty/models.py
+++ b/bionty/models.py
@@ -317,6 +317,13 @@ class HasSource(models.Model):
 
         # wetlab.Compound, bionty.CellType, etc.
         entity_name = cls.__get_name_with_module__()
+        if cls.require_organism():
+            if organism is None:
+                raise ValueError(
+                    "organism must be provided for organism-specific entities."
+                )
+            else:
+                organism = Organism.from_source(name=organism).save().name
         source_record = source if isinstance(source, Source) else None
         parquet_filename = None
 
@@ -328,9 +335,17 @@ class HasSource(models.Model):
             if organism:
                 filter_kwargs["organism"] = organism
 
+            # if source already exists in the instance
+            existing_sources = Source.filter(**filter_kwargs)
+            if existing_sources.count() > 1:
+                raise ValueError(
+                    f"multiple existing sources found in the database for {filter_kwargs}, please specify `version`."
+                )
+            elif existing_sources.count() == 1:
+                source_record = existing_sources.one()
+
             # if source is new and hasn't been registered in the instance yet
             # try to download the source via PublicOntology
-            source_record = Source.filter(**filter_kwargs).first()
             if not source_record:
                 source = PublicOntology(
                     source=source,
@@ -350,10 +365,6 @@ class HasSource(models.Model):
             "organism": source_record.organism,
         }
 
-        # Register organism if required
-        if cls.require_organism():
-            Organism.from_source(name=source_record.organism).save()
-
         # Get existing or create new source
         new_source = Source.filter(**unique_kwargs).one_or_none()
         if not new_source:
@@ -367,7 +378,7 @@ class HasSource(models.Model):
             ).save()
 
         # Return early if artifact already exists
-        if new_source.dataframe_artifact_id:
+        if new_source.dataframe_artifact_id and df is None:
             return new_source
 
         # Generate filename if not already created
@@ -389,8 +400,7 @@ class HasSource(models.Model):
             and isinstance(source, PublicOntology)
             and not source.to_dataframe().empty
         ):
-            # backwards compatible
-            df_artifact = getattr(ln.Artifact, "from_dataframe", ln.Artifact.from_df)(
+            df_artifact = ln.Artifact.from_dataframe(
                 source.to_dataframe(), key=parquet_filename, run=False
             )
 

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -317,14 +317,17 @@ class HasSource(models.Model):
 
         # wetlab.Compound, bionty.CellType, etc.
         entity_name = cls.__get_name_with_module__()
+        source_record = source if isinstance(source, Source) else None
         if cls.require_organism():
             if organism is None:
-                raise ValueError(
-                    "organism must be provided for organism-specific entities."
-                )
+                if source_record:
+                    organism = source_record.organism
+                else:
+                    raise ValueError(
+                        "organism must be provided for organism-specific entities."
+                    )
             else:
                 organism = Organism.from_source(name=organism).save().name
-        source_record = source if isinstance(source, Source) else None
         parquet_filename = None
 
         # Process source input and get source_record

--- a/bionty/models.py
+++ b/bionty/models.py
@@ -326,7 +326,7 @@ class HasSource(models.Model):
                     raise ValueError(
                         "organism must be provided for organism-specific entities."
                     )
-            else:
+            if organism:
                 organism = Organism.from_source(name=organism).save().name
         parquet_filename = None
 


### PR DESCRIPTION
- Make sure `version` is passed when there's ambiguity.
- Make sure `.dataframe_artifact` is updated when a new df is passed.