### PR TITLE
🔧 More minimal `pyproject.toml` to lower maintenance burden

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,10 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "bionty"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10"
 authors = [{name = "Lamin Labs", email = "open-source@lamin.ai"}]
 readme = "README.md"
 dynamic = ["version", "description"]
-classifiers = [
-    "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-]
 dependencies = [
     "lamindb-core>=2.3a1",
     "requests",


### PR DESCRIPTION
Now mimics the `pyproject.toml` of https://github.com/laminlabs/lamindb-setup.

Given `bionty` is a plugin module for `lamindb`, we can rely on `lamindb` for the qualifiers and hedging against new Python versions.