### PR TITLE
🍱 Updated ontology sources 2026-09

### DIFF
--- a/bionty/_organism.py
+++ b/bionty/_organism.py
@@ -48,10 +48,79 @@ def create_or_get_organism_record(
     return organism_record
 
 
+def _from_source_organism(**kwargs):
+    """Return an Organism from source, or None if the value is missing."""
+    from lamindb.errors import DoesNotExist
+
+    import bionty as bt
+
+    try:
+        record = bt.Organism.from_source(**kwargs)
+    except DoesNotExist:
+        return None
+    if isinstance(record, list):
+        if not record:
+            return None
+        # Ensembl lists strain assemblies under the same ontology_id; prefer the
+        # unsuffixed species row when present.
+        unsuffixed = [
+            item
+            for item in record
+            if getattr(item, "name", None) and " - " not in item.name
+        ]
+        return unsuffixed[0] if unsuffixed else record[0]
+    return record
+
+
+def _save_or_get_organism(organism_record, using_key: str | None = None):
+    """Reuse a DB record with the same ontology_id if present."""
+    import bionty as bt
+
+    if isinstance(organism_record, list):
+        organism_record = organism_record[0]
+    if organism_record.ontology_id:
+        existing = (
+            bt.Organism.connect(using_key)
+            .filter(ontology_id=organism_record.ontology_id)
+            .one_or_none()
+        )
+        if existing is not None:
+            return existing
+    organism_record.save(using=using_key)
+    return organism_record
+
+
+def get_or_create_organism_from_ontology_id(
+    ontology_id: str, using_key: str | None = None
+) -> Organism | None:
+    """Return a saved Organism with this ontology_id, creating it from source if needed."""
+    import bionty as bt
+
+    using_key = None if using_key == "default" else using_key
+    organism_record = (
+        bt.Organism.connect(using_key).filter(ontology_id=ontology_id).one_or_none()
+    )
+    if organism_record is not None:
+        return organism_record
+
+    organism_record = _from_source_organism(ontology_id=ontology_id)
+    if organism_record is None:
+        source = bt.Source.filter(name="ncbitaxon").first()
+        if source is not None:
+            organism_record = _from_source_organism(
+                ontology_id=ontology_id, source=source
+            )
+    if organism_record is None:
+        return None
+    return _save_or_get_organism(organism_record, using_key=using_key)
+
+
 def get_or_create_organism_from_name(
     name: str, using_key: str | None = None, error: bool = True
 ) -> Organism:
     """Create organism record if not exists."""
+    from lamindb.errors import DoesNotExist
+
     import bionty as bt
 
     using_key = None if using_key == "default" else using_key
@@ -63,29 +132,27 @@ def get_or_create_organism_from_name(
             bt.Organism.connect(using_key).filter(scientific_name=name).one_or_none()
         )
         if organism_record is None:
-            from lamindb.errors import DoesNotExist
-
             try:
-                organism_record = bt.Organism.from_source(
-                    name=name
-                )  # using default source
-                organism_record.save(using=using_key)
+                organism_record = bt.Organism.from_source(name=name)
+                organism_record = _save_or_get_organism(
+                    organism_record, using_key=using_key
+                )
             except DoesNotExist:
                 try:
-                    # try to create from ncbitaxon source
                     source = bt.Source.filter(name="ncbitaxon").first()
                     organism_record = bt.Organism.from_source(
                         scientific_name=name, source=source
                     )
-                    organism_record.save(using=using_key)
+                    organism_record = _save_or_get_organism(
+                        organism_record, using_key=using_key
+                    )
                 except DoesNotExist:
                     if error:
                         raise OrganismNotSet(
-                            f"Organism {name} can't be created from the source, check your spelling or create it manually."
+                            f"Organism {name} can't be created from the source, "
+                            "check your spelling or create it manually."
                         ) from None
-                    else:
-                        # for instance, organism="all" for CellLine should pass
-                        pass
+                    # else: organism="all" for CellLine should pass
     return organism_record
 
 
@@ -111,29 +178,62 @@ def infer_organism_from_ensembl_id(
 
     # for ensembl vertebrates, we infer organism from the ensembl prefix
     if prefix in ensembl_prefixes.index:
-        organism_name = ensembl_prefixes.loc[prefix, "name"]
-        # ensembl_prefixes can have duplicate entries for a prefix (e.g., ENSRNOG)
-        # when Ensembl lists both a canonical organism and strain-specific variants.
-        # In this case, loc returns a Series. We prefer names without " - " because
-        # Ensembl uses that delimiter to append strain/assembly qualifiers
-        # (for instance "Rat - SHR/Utx ..."), while the canonical species name stays
-        # unsuffixed (for instance "Rat"). If every entry is qualified, we take the
-        # shared base name before " - " when all variants agree; otherwise we fall
-        # back to the first value to keep inference resilient.
-        if isinstance(organism_name, pd.Series):
-            organism_names = organism_name.dropna().astype(str).str.lower()
-            canonical_names = organism_names[~organism_names.str.contains(r" - ")]
-            if len(canonical_names) > 0:
-                organism_name = canonical_names.iloc[0]
-            else:
-                base_names = organism_names.str.split(" - ", n=1).str[0].str.strip()
-                unique_base_names = base_names.drop_duplicates()
-                organism_name = (
-                    unique_base_names.iloc[0]
-                    if len(unique_base_names) == 1
-                    else organism_names.iloc[0]
-                )
-        else:
-            organism_name = str(organism_name).lower()
-        return get_or_create_organism_from_name(name=organism_name, using_key=using_key)
+        ontology_id = _ontology_id_from_ensembl_prefix(ensembl_prefixes, prefix)
+        if ontology_id is not None:
+            return get_or_create_organism_from_ontology_id(
+                ontology_id, using_key=using_key
+            )
+    return None
+
+
+def _ontology_id_from_ensembl_prefix(ensembl_prefixes, prefix: str) -> str | None:
+    """Map an Ensembl gene prefix to NCBITaxon ontology_id.
+
+    Prefix tables can list several assemblies for the same gene prefix (e.g.
+    ENSRNOG) and their common names change between Ensembl releases. Join to the
+    Ensembl organism table and return the ontology_id when it is unambiguous.
+    """
+    import pandas as pd
+
+    import bionty.base as bt_base
+
+    rows = ensembl_prefixes.loc[[prefix]]
+    if isinstance(rows, pd.Series):
+        rows = rows.to_frame().T
+
+    organism_df = bt_base.Organism(source="ensembl").to_dataframe()
+    if organism_df.index.name == "name":
+        organism_df = organism_df.reset_index()
+    if "ontology_id" not in organism_df.columns:
+        return None
+
+    matches = pd.DataFrame()
+    if "scientific_name" in rows.columns and "scientific_name" in organism_df.columns:
+        sci_names = rows["scientific_name"].dropna().astype(str).str.strip()
+        sci_names = sci_names[sci_names != ""].drop_duplicates()
+        if len(sci_names) > 0:
+            matches = organism_df[organism_df["scientific_name"].isin(sci_names)]
+    if matches.empty and "name" in organism_df.columns:
+        names = rows["name"].dropna().astype(str).str.lower()
+        canonical_names = names[~names.str.contains(r" - ", regex=True)]
+        query_names = canonical_names if len(canonical_names) > 0 else names
+        matches = organism_df[
+            organism_df["name"].astype(str).str.lower().isin(query_names)
+        ]
+    if matches.empty:
+        return None
+
+    ontology_ids = matches["ontology_id"].dropna().astype(str).drop_duplicates()
+    if len(ontology_ids) == 1:
+        return ontology_ids.iloc[0]
+    if "name" in matches.columns:
+        canonical = matches[
+            ~matches["name"].astype(str).str.contains(r" - ", regex=True)
+        ]
+        if not canonical.empty:
+            ontology_ids = (
+                canonical["ontology_id"].dropna().astype(str).drop_duplicates()
+            )
+            if len(ontology_ids) >= 1:
+                return ontology_ids.iloc[0]
     return None

--- a/bionty/base/entities/_cellline.py
+++ b/bionty/base/entities/_cellline.py
@@ -31,6 +31,7 @@ class CellLine(PublicOntology):
         source: Literal["cellosaurus", "clo", "depmap"] | None = None,
         version: Literal[
             # cellosaurus
+            "56.0",
             "53.0",
             # clo
             "2023-03-28",

--- a/bionty/base/entities/_celltype.py
+++ b/bionty/base/entities/_celltype.py
@@ -24,6 +24,7 @@ class CellType(PublicOntology):
         organism: Literal["all"] | None = None,
         source: Literal["cl"] | None = None,
         version: Literal[
+            "2026-06-08",
             "2025-12-17",
             "2025-04-10",
             "2024-08-16",

--- a/bionty/base/entities/_disease.py
+++ b/bionty/base/entities/_disease.py
@@ -34,6 +34,7 @@ class Disease(PublicOntology):
         source: Literal["mondo", "doid", "icd"] | None = None,
         version: Literal[
             # Mondo
+            "2026-09-01",
             "2026-01-06",
             "2025-06-03",
             "2024-08-06",
@@ -47,6 +48,7 @@ class Disease(PublicOntology):
             "2022-10-11",
             "2023-04-04",
             # DOID
+            "2026-08-31",
             "2025-12-23",
             "2025-05-30",
             "2024-05-29",

--- a/bionty/base/entities/_drug.py
+++ b/bionty/base/entities/_drug.py
@@ -28,13 +28,14 @@ class Drug(PublicOntology):
         organism: Literal["all"] | None = None,
         source: Literal["dron", "chebi"] | None = None,
         version: Literal[
+            # CHEBI
+            "2026-09-01",
+            "2024-07-27",
+            "2024-03-02",
             # DRON
             "2025-04-18",
             "2024-08-05",
             "2023-03-10",
-            # CHEBI
-            "2024-07-27",
-            "2024-03-02",
         ]
         | None = None,
         **kwargs,

--- a/bionty/base/entities/_experimentalfactor.py
+++ b/bionty/base/entities/_experimentalfactor.py
@@ -26,6 +26,7 @@ class ExperimentalFactor(PublicOntology):
         organism: Literal["all"] | None = None,
         source: Literal["efo"] | None = None,
         version: Literal[
+            "3.93.0",
             "3.85.0",
             "3.78.0",
             "3.70.0",

--- a/bionty/base/entities/_gene.py
+++ b/bionty/base/entities/_gene.py
@@ -59,6 +59,9 @@ class Gene(PublicOntology):
         organism: Literal["human", "mouse", "saccharomyces cerevisiae"] | None = None,
         source: Literal["ensembl"] | None = None,
         version: Literal[
+            # Ensembl
+            "release-116",
+            "release-115",
             "release-114",
             "release-113",
             "release-112",

--- a/bionty/base/entities/_gene.py
+++ b/bionty/base/entities/_gene.py
@@ -34,6 +34,11 @@ class MappingResult(NamedTuple):
     unmapped: list[str]
 
 
+def _join_synonyms(values) -> str:
+    """Join unique synonym strings, skipping NULL/NaN from Ensembl."""
+    return "|".join(i for i in set(values) if isinstance(i, str) and i)
+
+
 @_doc_params(doc_entities=doc_entites)
 class Gene(PublicOntology):
     """Gene.
@@ -263,7 +268,7 @@ class EnsemblGene:
                 "display_label": "first",
                 "biotype": "first",
                 "description": "first",
-                "synonym": lambda x: "|".join([i for i in set(x) if i is not None]),
+                "synonym": _join_synonyms,
             }
         )
 

--- a/bionty/base/entities/_organism.py
+++ b/bionty/base/entities/_organism.py
@@ -37,10 +37,13 @@ class Organism(PublicOntology):
         version: (
             Literal[
                 # NCBITaxon
+                "2026-07-12",
                 "2025-12-03",
                 "2025-03-13",
                 "2023-06-20",
                 # Ensembl
+                "release-116",
+                "release-115",
                 "release-114",
                 "release-113",
                 "release-112",

--- a/bionty/base/entities/_organism.py
+++ b/bionty/base/entities/_organism.py
@@ -103,8 +103,7 @@ class Organism(PublicOntology):
                     # add synonyms column if it doesn't exist
                     df["synonyms"] = None
                 return _standardize_scientific_name(df)
-        else:
-            return super()._load_df()
+        return super()._load_df()
 
     def to_dataframe(self) -> DataFrame:
         """Pandas DataFrame of the ontology.
@@ -125,12 +124,15 @@ class Organism(PublicOntology):
         return self.to_dataframe()
 
 
-def _standardize_scientific_name(df: DataFrame) -> DataFrame:
-    """Standardize scientific name following NCBITaxon convention.
+def _format_scientific_name(value):
+    """Standardize Ensembl species names: homo_sapiens -> Homo sapiens."""
+    if not isinstance(value, str) or "_" not in value:
+        return value
+    parts = value.split("_")
+    return " ".join([parts[0].capitalize(), *parts[1:]])
 
-    homo_sapiens -> Homo sapiens
-    """
-    df["scientific_name"] = df["scientific_name"].apply(
-        lambda x: " ".join([x.split("_")[0].capitalize()] + x.split("_")[1:])
-    )
+
+def _standardize_scientific_name(df: DataFrame) -> DataFrame:
+    """Standardize scientific name following NCBITaxon convention."""
+    df["scientific_name"] = df["scientific_name"].apply(_format_scientific_name)
     return df

--- a/bionty/base/entities/_pathway.py
+++ b/bionty/base/entities/_pathway.py
@@ -28,6 +28,7 @@ class Pathway(PublicOntology):
         source: Literal["go", "pw"] | None = None,
         version: Literal[
             # Gene Ontology
+            "2026-05-16",
             "2025-10-10",
             "2024-11-03",
             "2024-06-17",

--- a/bionty/base/entities/_phenotype.py
+++ b/bionty/base/entities/_phenotype.py
@@ -34,6 +34,7 @@ class Phenotype(PublicOntology):
         source: Literal["hp", "phe", "pato"] | None = None,
         version: Literal[
             # HP
+            "2026-09-01",
             "2026-01-08",
             "2025-05-06",
             "2024-04-26",

--- a/bionty/base/entities/_tissue.py
+++ b/bionty/base/entities/_tissue.py
@@ -24,6 +24,7 @@ class Tissue(PublicOntology):
         organism: Literal["all"] | None = None,
         source: Literal["uberon"] | None = None,
         version: Literal[
+            "2026-06-23",
             "2025-12-04",
             "2025-05-28",
             "2024-08-07",

--- a/bionty/base/sources.yaml
+++ b/bionty/base/sources.yaml
@@ -1,8 +1,8 @@
-version: "0.3.1"
+version: "0.4.0"
 Organism:
   ensembl:
     vertebrates:
-      latest-version: release-114
+      latest-version: release-116
       url: https://ftp.ensembl.org/pub/{version}/species_EnsemblVertebrates.txt
     bacteria:
       latest-version: release-57
@@ -20,20 +20,20 @@ Organism:
     website: https://www.ensembl.org
   ncbitaxon:
     all:
-      latest-version: 2025-12-03
+      latest-version: 2026-07-12
       url: http://purl.obolibrary.org/obo/ncbitaxon/{version}/ncbitaxon.owl
     name: NCBItaxon Ontology
     website: https://github.com/obophenotype/ncbitaxon
 Gene:
   ensembl:
     human:
-      latest-version: release-114
+      latest-version: release-116
       url: s3://bionty-assets/df_human__ensembl__{version}__Gene.parquet
     mouse:
-      latest-version: release-114
+      latest-version: release-116
       url: s3://bionty-assets/df_mouse__ensembl__{version}__Gene.parquet
     saccharomyces cerevisiae:
-      latest-version: release-114
+      latest-version: release-116
       url: s3://bionty-assets/df_saccharomyces-cerevisiae__ensembl__{version}__Gene.parquet
     name: Ensembl
     website: https://www.ensembl.org

--- a/bionty/base/sources.yaml
+++ b/bionty/base/sources.yaml
@@ -34,7 +34,7 @@ Gene:
       url: s3://bionty-assets/df_mouse__ensembl__{version}__Gene.parquet
     saccharomyces cerevisiae:
       latest-version: release-114
-      url: s3://bionty-assets/df_saccharomyces cerevisiae__ensembl__{version}__Gene.parquet
+      url: s3://bionty-assets/df_saccharomyces-cerevisiae__ensembl__{version}__Gene.parquet
     name: Ensembl
     website: https://www.ensembl.org
 Protein:

--- a/bionty/base/sources.yaml
+++ b/bionty/base/sources.yaml
@@ -1,4 +1,4 @@
-version: "0.3.0"
+version: "0.3.1"
 Organism:
   ensembl:
     vertebrates:
@@ -88,7 +88,7 @@ CellMarker:
 CellLine:
   cellosaurus:
     all:
-      latest-version: 53.0
+      latest-version: 56.0
       url: s3://bionty-assets/df_all__cellosaurus__{version}__CellLine.parquet
     name: Cellosaurus
     website: https://www.cellosaurus.org/
@@ -107,27 +107,27 @@ CellLine:
 CellType:
   cl:
     all:
-      latest-version: 2025-12-17
+      latest-version: 2026-06-08
       url: http://purl.obolibrary.org/obo/cl/releases/{version}/cl.owl
     name: Cell Ontology
     website: https://obophenotype.github.io/cell-ontology
 Tissue:
   uberon:
     all:
-      latest-version: 2025-12-04
-      url: http://purl.obolibrary.org/obo/uberon/releases/{version}/uberon.owl
+      latest-version: 2026-06-23
+      url: https://github.com/obophenotype/uberon/releases/download/v{version}/uberon.owl
     name: Uberon multi-species anatomy ontology
     website: http://obophenotype.github.io/uberon
 Disease:
   mondo:
     all:
-      latest-version: 2026-01-06
+      latest-version: 2026-09-01
       url: http://purl.obolibrary.org/obo/mondo/releases/{version}/mondo.owl
     name: Mondo Disease Ontology
     website: https://mondo.monarchinitiative.org
   doid:
     human:
-      latest-version: 2025-12-23
+      latest-version: 2026-08-31
       url: http://purl.obolibrary.org/obo/doid/releases/{version}/doid.obo
     name: Human Disease Ontology
     website: https://disease-ontology.org
@@ -140,7 +140,7 @@ Disease:
 ExperimentalFactor:
   efo:
     all:
-      latest-version: 3.85.0
+      latest-version: 3.93.0
       url: https://github.com/EBISPOT/efo/releases/download/v{version}/efo.owl
     name: The Experimental Factor Ontology
     website: https://bioportal.bioontology.org/ontologies/EFO
@@ -153,7 +153,7 @@ Phenotype:
     website: https://github.com/pato-ontology/pato
   hp:
     human:
-      latest-version: 2026-01-08
+      latest-version: 2026-09-01
       url: https://github.com/obophenotype/human-phenotype-ontology/releases/download/v{version}/hp.owl
     name: Human Phenotype Ontology
     website: https://hpo.jax.org
@@ -172,7 +172,7 @@ Pathway:
     website: http://geneontology.org
   pw:
     all:
-      latest-version: 7.96
+      latest-version: 2026-05-16
       url: http://purl.obolibrary.org/obo/pw/{version}/pw.owl
     name: Pathway Ontology
     website: https://www.ebi.ac.uk/ols/ontologies/pw
@@ -184,18 +184,18 @@ BFXPipeline:
     name: Bioinformatics Pipeline
     website: https://lamin.ai
 Drug:
+  chebi:
+    all:
+      latest-version: 2026-09-01
+      url: s3://bionty-assets/df_all__chebi__{version}__Drug.parquet
+    name: Chemical Entities of Biological Interest
+    website: https://www.ebi.ac.uk/chebi/
   dron:
     all:
       latest-version: 2024-08-05
       url: http://purl.obolibrary.org/obo/dron/releases/{version}/dron.owl
     name: Drug Ontology
     website: https://bioportal.bioontology.org/ontologies/DRON
-  chebi:
-    all:
-      latest-version: 2024-07-27
-      url: s3://bionty-assets/df_all__chebi__{version}__Drug.parquet
-    name: Chemical Entities of Biological Interest
-    website: https://www.ebi.ac.uk/chebi/
 DevelopmentalStage:
   hsapdv:
     human:

--- a/bionty/core/_source.py
+++ b/bionty/core/_source.py
@@ -178,6 +178,7 @@ def register_source_in_bionty_assets(
     source: SQLRecord,
     is_dataframe: bool = True,
     update: bool = False,
+    assert_entity: bool = True,
 ) -> Artifact:
     """Register a new source in the laminlabs/bionty-assets instance.
 
@@ -213,7 +214,7 @@ def register_source_in_bionty_assets(
 
     # assert ln.setup.settings.instance.slug == "laminlabs/bionty-assets"
 
-    if "." not in source.entity:
+    if assert_entity and "." not in source.entity:
         raise ValueError(
             "source entity must be in form of 'module.ClassName', e.g. 'bionty.Gene'"
         )
@@ -248,7 +249,8 @@ def register_source_in_bionty_assets(
         assert organism == source.organism.lower().replace(" ", "-")
         assert source_name == source.name
         assert version == source.version
-        assert entity == source.entity.split(".")[-1]
+        if assert_entity:
+            assert entity == source.entity.split(".")[-1]
         source.dataframe_artifact = artifact
         source.save()
         logger.print(

--- a/tests/base/entities/test_gene.py
+++ b/tests/base/entities/test_gene.py
@@ -1,7 +1,7 @@
 import bionty.base as bt_base
 import pandas as pd
 import pytest
-from bionty.base.entities._gene import MappingResult
+from bionty.base.entities._gene import MappingResult, _join_synonyms
 
 
 @pytest.fixture(scope="module")
@@ -32,6 +32,22 @@ def test_gene_ensembl_inspect_hgnc_id(genes):
     expected_series = pd.Series([True, True, True, False])
 
     assert inspect.equals(expected_series)
+
+
+def test_join_synonyms_skips_nulls():
+    joined = _join_synonyms(["ABC", float("nan"), None, "ABC", "DEF", "", pd.NA])
+    assert set(joined.split("|")) == {"ABC", "DEF"}
+    assert _join_synonyms([float("nan"), None, "", pd.NA]) == ""
+
+    df = pd.DataFrame(
+        {
+            "stable_id": ["g1", "g1", "g2"],
+            "synonym": ["ABC", float("nan"), None],
+        }
+    )
+    result = df.groupby("stable_id").agg({"synonym": _join_synonyms})
+    assert result.loc["g1", "synonym"] == "ABC"
+    assert result.loc["g2", "synonym"] == ""
 
 
 def test_ensemblgene_download():

--- a/tests/core/test_organism_requirement.py
+++ b/tests/core/test_organism_requirement.py
@@ -55,7 +55,8 @@ def test_infer_organism_from_ensembl_id():
     ).save()
     organism = infer_organism_from_ensembl_id("ENSRNOG00000001284")
     assert organism is not None
-    assert organism.name == "rat"
+    # Common names change across Ensembl/NCBITaxon versions; ontology_id does not.
+    assert organism.ontology_id == "NCBITaxon:10116"
 
 
 def test_pass_scientific_name_as_organism():

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -60,11 +60,11 @@ def test_add_source():
     # pass a source record from another entity
     with pytest.raises(ValueError):
         pertdb.Compound.import_source()
-    chebi_source = bt.Source.get(name="chebi", version="2024-07-27")
+    chebi_source = bt.Source.get(name="chebi", version="2026-09-01")
     new_source = pertdb.Compound.add_source(chebi_source)
     assert new_source.entity == "pertdb.Compound"
     assert new_source.name == "chebi"
-    assert new_source.version == "2024-07-27"
+    assert new_source.version == "2026-09-01"
     assert new_source.dataframe_artifact is not None
     public_ontology = pertdb.Compound.public()
     assert public_ontology.__class__.__name__ == "StaticReference"


### PR DESCRIPTION
# Updated sources
- [standard ontologies](https://lamin.ai/laminlabs/bionty-assets/transform/7extigZj6QNG0002)
   - `Disease|mondo|all|2026-09-01`
   - `CellType|cl|all|2026-06-08`
   - `Disease|doid|human|2026-08-31`
   - `ExperimentalFactor|efo|all|3.93.0`
   - `Phenotype|hp|human|2026-09-01`
   - `Pathway|pw|all|2026-05-16`
   - `Tissue|uberon|all|2026-06-23`
- [Drug|chebi|all|2026-09-01](https://lamin.ai/laminlabs/bionty-assets/transform/fQpBV2oEQUFi0001)
- [CellLine|cellosaurus|all|56.0](https://lamin.ai/laminlabs/bionty-assets/transform/KKctRIWTJkl10001)
- [Organism|ensembl|release-115](https://lamin.ai/laminlabs/bionty-assets/transform/nFWyLouIPVNr0002)
- [Organism|ensembl|release-116](https://lamin.ai/laminlabs/bionty-assets/transform/nFWyLouIPVNr0003)
- [Organism|ncbitaxon|all|2026-07-12](https://lamin.ai/laminlabs/bionty-assets/transform/lrvYWxWrgiMu0001)
- [Gene|ensembl|release-115](https://lamin.ai/laminlabs/bionty-assets/transform/29QKnEHJbeDQ0002)
- [Gene|ensembl|release-116](https://lamin.ai/laminlabs/bionty-assets/transform/29QKnEHJbeDQ0003)